### PR TITLE
add enumerateExports

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -114,6 +114,18 @@ Session.prototype.writeUtf8 = function (address, string) {
   });
 };
 
+Session.prototype.enumerateExports = function (moduleName) {
+  return this[request]('module:enumerate-exports', {
+    modulePath: moduleName
+  })
+  .then(function (result) {
+    return result.exports.map(function (e) {
+      e.address = ptr(e.address);
+      return e;
+    });
+  });
+}
+
 Session.prototype.createScript = function (source, options) {
   options = options || {};
   var name = options.name || null;


### PR DESCRIPTION
module:enumerate-ranges is still missing, but we already have process:enumerate-ranges, so I'm not sure how exactly you want to work with the conflicting name. Maybe enumerateModuleRanges or moduleEnumerateRanges?