### PR TITLE
Change session.enumerateRanges to accommodate a scope to allow searching...

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -63,8 +63,16 @@ Session.prototype.enumerateModules = function () {
   return this[modulesPromise];
 };
 
-Session.prototype.enumerateRanges = function (protection) {
-  return this[request]('process:enumerate-ranges', { protection: protection })
+Session.prototype.enumerateRanges = function (protection, options) {
+  options = options || {};
+  var scope = options.scope || null;
+  var name = "process:enumerate-ranges";
+  var data = { protection: protection };
+  if (scope !== undefined) {
+    name = "module:enumerate-ranges";
+    data.modulePath = scope;
+  }
+  return this[request](name, data)
   .then(function (result) {
     return result.ranges.map(function (r) {
       return new Range(ptr(r.base), r.size, r.protection);
@@ -124,7 +132,7 @@ Session.prototype.enumerateExports = function (moduleName) {
       return e;
     });
   });
-}
+};
 
 Session.prototype.createScript = function (source, options) {
   options = options || {};


### PR DESCRIPTION
... within a module.

If a scope is specified, Module.enumerateRanges is used instead of
Process.enumerateRanges, so you can search a range within a module.

```js
session.enumerateRanges('rw-', {
  scope: "libSystem.B.dylib" // etc
});
```