### PR TITLE
Support Nan 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "big-integer": "^1.4.4",
     "minimatch": "*",
-    "nan": "^1.8.4",
+    "nan": "^2.0.0",
     "node-pre-gyp": "0.6.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "big-integer": "^1.4.4",
     "minimatch": "*",
-    "nan": "^2.0.0",
+    "nan": "^2.0.4",
     "node-pre-gyp": "0.6.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "big-integer": "^1.4.4",
     "minimatch": "*",
-    "nan": "^2.0.4",
+    "nan": "^2.0.5",
     "node-pre-gyp": "0.6.x"
   },
   "devDependencies": {

--- a/src/application.cc
+++ b/src/application.cc
@@ -16,9 +16,7 @@ using v8::Isolate;
 using v8::Local;
 using v8::Object;
 using v8::ReadOnly;
-using v8::String;
 using v8::Value;
-using v8::Persistent;
 using Nan::HandleScope;
 
 namespace frida {
@@ -36,7 +34,7 @@ void Application::Init(Handle<Object> exports, Runtime* runtime) {
   auto isolate = Isolate::GetCurrent();
 
   auto name = Nan::New("Application").ToLocalChecked();
-  auto tpl = CreateTemplate(isolate, name, Application::New, runtime);
+  auto tpl = CreateTemplate(name, Application::New, runtime);
 
   auto instance_tpl = tpl->InstanceTemplate();
   auto data = Handle<Value>();
@@ -55,17 +53,16 @@ void Application::Init(Handle<Object> exports, Runtime* runtime) {
   auto ctor = Nan::GetFunction(tpl).ToLocalChecked();
   Nan::Set(exports, name, ctor);
   runtime->SetDataPointer(APPLICATION_DATA_CONSTRUCTOR,
-      new v8::Persistent<Function>(isolate, ctor));
+      new v8::Persistent<v8::Function>(isolate, ctor));
 }
 
 Local<Object> Application::New(gpointer handle, Runtime* runtime) {
-  auto isolate = Isolate::GetCurrent();
-
-  auto ctor = Local<Function>::New(isolate,
-      *static_cast<v8::Persistent<Function>*>(
+  auto ctor = Nan::New<v8::Function>(
+    *static_cast<v8::Persistent<v8::Function>*>(
       runtime->GetDataPointer(APPLICATION_DATA_CONSTRUCTOR)));
+
   const int argc = 1;
-  Local<Value> argv[argc] = { External::New(isolate, handle) };
+  Local<Value> argv[argc] = { Nan::New<v8::External>(handle) };
   return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 

--- a/src/application.cc
+++ b/src/application.cc
@@ -69,7 +69,7 @@ Local<Object> Application::New(gpointer handle, Runtime* runtime) {
   return ctor->NewInstance(argc, argv);
 }
 
-void Application::New(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Application::New) {
   HandleScope();
 
   if (info.IsConstructCall()) {
@@ -91,8 +91,7 @@ void Application::New(const Nan::FunctionCallbackInfo<Value>& info) {
   }
 }
 
-void Application::GetIdentifier(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Application::GetIdentifier) {
   HandleScope();
 
   auto handle = ObjectWrap::Unwrap<Application>(
@@ -102,8 +101,7 @@ void Application::GetIdentifier(Local<String> property,
       Nan::New(frida_application_get_identifier(handle)).ToLocalChecked());
 }
 
-void Application::GetName(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Application::GetName) {
   HandleScope();
 
   auto handle = ObjectWrap::Unwrap<Application>(
@@ -113,8 +111,7 @@ void Application::GetName(Local<String> property,
       Nan::New(frida_application_get_name(handle)).ToLocalChecked());
 }
 
-void Application::GetPid(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Application::GetPid) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -125,8 +122,7 @@ void Application::GetPid(Local<String> property,
       Integer::NewFromUnsigned(isolate, frida_application_get_pid(handle)));
 }
 
-void Application::GetSmallIcon(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Application::GetSmallIcon) {
   HandleScope();
 
   auto wrapper = ObjectWrap::Unwrap<Application>(info.Holder());
@@ -136,8 +132,7 @@ void Application::GetSmallIcon(Local<String> property,
       Icon::New(frida_application_get_small_icon(handle), wrapper->runtime_));
 }
 
-void Application::GetLargeIcon(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Application::GetLargeIcon) {
   HandleScope();
 
   auto wrapper = ObjectWrap::Unwrap<Application>(info.Holder());

--- a/src/application.cc
+++ b/src/application.cc
@@ -8,20 +8,18 @@
 
 using v8::AccessorSignature;
 using v8::DEFAULT;
-using v8::Exception;
 using v8::External;
 using v8::Function;
-using v8::FunctionCallbackInfo;
 using v8::Handle;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
-using v8::Persistent;
-using v8::PropertyCallbackInfo;
 using v8::ReadOnly;
 using v8::String;
 using v8::Value;
+using v8::Persistent;
+using Nan::HandleScope;
 
 namespace frida {
 
@@ -37,115 +35,115 @@ Application::~Application() {
 void Application::Init(Handle<Object> exports, Runtime* runtime) {
   auto isolate = Isolate::GetCurrent();
 
-  auto name = NanNew("Application");
-  auto tpl = CreateTemplate(isolate, name, New, runtime);
+  auto name = Nan::New("Application").ToLocalChecked();
+  auto tpl = CreateTemplate(isolate, name, Application::New, runtime);
 
   auto instance_tpl = tpl->InstanceTemplate();
   auto data = Handle<Value>();
   auto signature = AccessorSignature::New(isolate, tpl);
-  instance_tpl->SetAccessor(NanNew("identifier"),
+  Nan::SetAccessor(instance_tpl, Nan::New("identifier").ToLocalChecked(),
       GetIdentifier, 0, data, DEFAULT, ReadOnly, signature);
-  instance_tpl->SetAccessor(NanNew("name"),
+  Nan::SetAccessor(instance_tpl, Nan::New("name").ToLocalChecked(),
       GetName, 0, data, DEFAULT, ReadOnly, signature);
-  instance_tpl->SetAccessor(NanNew("pid"),
+  Nan::SetAccessor(instance_tpl, Nan::New("pid").ToLocalChecked(),
       GetPid, 0, data, DEFAULT, ReadOnly, signature);
-  instance_tpl->SetAccessor(NanNew("smallIcon"),
+  Nan::SetAccessor(instance_tpl, Nan::New("smallIcon").ToLocalChecked(),
       GetSmallIcon, 0, data, DEFAULT, ReadOnly, signature);
-  instance_tpl->SetAccessor(NanNew("largeIcon"),
+  Nan::SetAccessor(instance_tpl, Nan::New("largeIcon").ToLocalChecked(),
       GetLargeIcon, 0, data, DEFAULT, ReadOnly, signature);
 
-  auto ctor = tpl->GetFunction();
-  exports->Set(name, ctor);
+  auto ctor = Nan::GetFunction(tpl).ToLocalChecked();
+  Nan::Set(exports, name, ctor);
   runtime->SetDataPointer(APPLICATION_DATA_CONSTRUCTOR,
-      new Persistent<Function>(isolate, ctor));
+      new v8::Persistent<Function>(isolate, ctor));
 }
 
 Local<Object> Application::New(gpointer handle, Runtime* runtime) {
   auto isolate = Isolate::GetCurrent();
 
   auto ctor = Local<Function>::New(isolate,
-      *static_cast<Persistent<Function>*>(
+      *static_cast<v8::Persistent<Function>*>(
       runtime->GetDataPointer(APPLICATION_DATA_CONSTRUCTOR)));
   const int argc = 1;
   Local<Value> argv[argc] = { External::New(isolate, handle) };
   return ctor->NewInstance(argc, argv);
 }
 
-void Application::New(const FunctionCallbackInfo<Value>& args) {
-  NanScope();
+void Application::New(const Nan::FunctionCallbackInfo<Value>& info) {
+  HandleScope();
 
-  if (args.IsConstructCall()) {
-    if (args.Length() != 1 || !args[0]->IsExternal()) {
-      NanThrowTypeError("Bad argument, expected raw handle");
-      NanReturnUndefined();
+  if (info.IsConstructCall()) {
+    if (info.Length() != 1 || !info[0]->IsExternal()) {
+      Nan::ThrowTypeError("Bad argument, expected raw handle");
+      return;
     }
-    auto runtime = GetRuntimeFromConstructorArgs(args);
+    auto runtime = GetRuntimeFromConstructorArgs(info);
 
     auto handle = static_cast<FridaApplication*>(
-        Local<External>::Cast(args[0])->Value());
+        Local<External>::Cast(info[0])->Value());
     auto wrapper = new Application(handle, runtime);
-    auto obj = args.This();
+    auto obj = info.This();
     wrapper->Wrap(obj);
 
-    NanReturnValue(obj);
+    info.GetReturnValue().Set(obj);
   } else {
-    NanReturnValue(args.Callee()->NewInstance(0, NULL));
+    info.GetReturnValue().Set(info.Callee()->NewInstance(0, NULL));
   }
 }
 
 void Application::GetIdentifier(Local<String> property,
-    const PropertyCallbackInfo<Value>& args) {
-  NanScope();
+    const Nan::PropertyCallbackInfo<Value>& info) {
+  HandleScope();
 
   auto handle = ObjectWrap::Unwrap<Application>(
-      args.Holder())->GetHandle<FridaApplication>();
+      info.Holder())->GetHandle<FridaApplication>();
 
-  NanReturnValue(
-      NanNew(frida_application_get_identifier(handle)));
+  info.GetReturnValue().Set(
+      Nan::New(frida_application_get_identifier(handle)).ToLocalChecked());
 }
 
 void Application::GetName(Local<String> property,
-    const PropertyCallbackInfo<Value>& args) {
-  NanScope();
+    const Nan::PropertyCallbackInfo<Value>& info) {
+  HandleScope();
 
   auto handle = ObjectWrap::Unwrap<Application>(
-      args.Holder())->GetHandle<FridaApplication>();
+      info.Holder())->GetHandle<FridaApplication>();
 
-  NanReturnValue(
-      NanNew(frida_application_get_name(handle)));
+  info.GetReturnValue().Set(
+      Nan::New(frida_application_get_name(handle)).ToLocalChecked());
 }
 
 void Application::GetPid(Local<String> property,
-    const PropertyCallbackInfo<Value>& args) {
-  NanScope();
+    const Nan::PropertyCallbackInfo<Value>& info) {
+  HandleScope();
 
-  auto isolate = args.GetIsolate();
+  auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Application>(
-      args.Holder())->GetHandle<FridaApplication>();
+      info.Holder())->GetHandle<FridaApplication>();
 
-  NanReturnValue(
+  info.GetReturnValue().Set(
       Integer::NewFromUnsigned(isolate, frida_application_get_pid(handle)));
 }
 
 void Application::GetSmallIcon(Local<String> property,
-    const PropertyCallbackInfo<Value>& args) {
-  NanScope();
+    const Nan::PropertyCallbackInfo<Value>& info) {
+  HandleScope();
 
-  auto wrapper = ObjectWrap::Unwrap<Application>(args.Holder());
+  auto wrapper = ObjectWrap::Unwrap<Application>(info.Holder());
   auto handle = wrapper->GetHandle<FridaApplication>();
 
-  NanReturnValue(
+  info.GetReturnValue().Set(
       Icon::New(frida_application_get_small_icon(handle), wrapper->runtime_));
 }
 
 void Application::GetLargeIcon(Local<String> property,
-    const PropertyCallbackInfo<Value>& args) {
-  NanScope();
+    const Nan::PropertyCallbackInfo<Value>& info) {
+  HandleScope();
 
-  auto wrapper = ObjectWrap::Unwrap<Application>(args.Holder());
+  auto wrapper = ObjectWrap::Unwrap<Application>(info.Holder());
   auto handle = wrapper->GetHandle<FridaApplication>();
 
-  NanReturnValue(
+  info.GetReturnValue().Set(
       Icon::New(frida_application_get_large_icon(handle), wrapper->runtime_));
 }
 

--- a/src/application.cc
+++ b/src/application.cc
@@ -66,7 +66,7 @@ Local<Object> Application::New(gpointer handle, Runtime* runtime) {
       runtime->GetDataPointer(APPLICATION_DATA_CONSTRUCTOR)));
   const int argc = 1;
   Local<Value> argv[argc] = { External::New(isolate, handle) };
-  return ctor->NewInstance(argc, argv);
+  return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 
 NAN_METHOD(Application::New) {

--- a/src/application.cc
+++ b/src/application.cc
@@ -70,7 +70,7 @@ Local<Object> Application::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Application::New) {
-  HandleScope();
+  HandleScope scope;
 
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
@@ -92,7 +92,7 @@ NAN_METHOD(Application::New) {
 }
 
 NAN_PROPERTY_GETTER(Application::GetIdentifier) {
-  HandleScope();
+  HandleScope scope;
 
   auto handle = ObjectWrap::Unwrap<Application>(
       info.Holder())->GetHandle<FridaApplication>();
@@ -102,7 +102,7 @@ NAN_PROPERTY_GETTER(Application::GetIdentifier) {
 }
 
 NAN_PROPERTY_GETTER(Application::GetName) {
-  HandleScope();
+  HandleScope scope;
 
   auto handle = ObjectWrap::Unwrap<Application>(
       info.Holder())->GetHandle<FridaApplication>();
@@ -112,7 +112,7 @@ NAN_PROPERTY_GETTER(Application::GetName) {
 }
 
 NAN_PROPERTY_GETTER(Application::GetPid) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Application>(
@@ -123,7 +123,7 @@ NAN_PROPERTY_GETTER(Application::GetPid) {
 }
 
 NAN_PROPERTY_GETTER(Application::GetSmallIcon) {
-  HandleScope();
+  HandleScope scope;
 
   auto wrapper = ObjectWrap::Unwrap<Application>(info.Holder());
   auto handle = wrapper->GetHandle<FridaApplication>();
@@ -133,7 +133,7 @@ NAN_PROPERTY_GETTER(Application::GetSmallIcon) {
 }
 
 NAN_PROPERTY_GETTER(Application::GetLargeIcon) {
-  HandleScope();
+  HandleScope scope;
 
   auto wrapper = ObjectWrap::Unwrap<Application>(info.Holder());
   auto handle = wrapper->GetHandle<FridaApplication>();

--- a/src/application.h
+++ b/src/application.h
@@ -17,18 +17,13 @@ class Application : public GLibObject {
   explicit Application(FridaApplication* handle, Runtime* runtime);
   ~Application();
 
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(New);
 
-  static void GetIdentifier(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetName(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetPid(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetSmallIcon(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetLargeIcon(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
+  static NAN_PROPERTY_GETTER(GetIdentifier);
+  static NAN_PROPERTY_GETTER(GetName);
+  static NAN_PROPERTY_GETTER(GetPid);
+  static NAN_PROPERTY_GETTER(GetSmallIcon);
+  static NAN_PROPERTY_GETTER(GetLargeIcon);
 };
 
 }

--- a/src/application.h
+++ b/src/application.h
@@ -4,6 +4,7 @@
 #include "glib_object.h"
 
 #include <frida-core.h>
+#include <nan.h>
 
 namespace frida {
 
@@ -16,18 +17,18 @@ class Application : public GLibObject {
   explicit Application(FridaApplication* handle, Runtime* runtime);
   ~Application();
 
-  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   static void GetIdentifier(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetName(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetPid(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetSmallIcon(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetLargeIcon(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
 };
 
 }

--- a/src/device.cc
+++ b/src/device.cc
@@ -87,7 +87,7 @@ Local<Object> Device::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Device::New) {
-  HandleScope();
+  HandleScope scope;
 
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
@@ -111,7 +111,7 @@ NAN_METHOD(Device::New) {
 }
 
 NAN_PROPERTY_GETTER(Device::GetId) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Device>(
@@ -122,7 +122,7 @@ NAN_PROPERTY_GETTER(Device::GetId) {
 }
 
 NAN_PROPERTY_GETTER(Device::GetName) {
-  HandleScope();
+  HandleScope scope;
 
   auto handle = ObjectWrap::Unwrap<Device>(
       info.Holder())->GetHandle<FridaDevice>();
@@ -132,7 +132,7 @@ NAN_PROPERTY_GETTER(Device::GetName) {
 }
 
 NAN_PROPERTY_GETTER(Device::GetIcon) {
-  HandleScope();
+  HandleScope scope;
 
   auto wrapper = ObjectWrap::Unwrap<Device>(info.Holder());
   auto handle = wrapper->GetHandle<FridaDevice>();
@@ -142,7 +142,7 @@ NAN_PROPERTY_GETTER(Device::GetIcon) {
 }
 
 NAN_PROPERTY_GETTER(Device::GetType) {
-  HandleScope();
+  HandleScope scope;
 
   auto handle = ObjectWrap::Unwrap<Device>(
       info.Holder())->GetHandle<FridaDevice>();
@@ -190,7 +190,7 @@ class GetFrontmostApplicationOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::GetFrontmostApplication) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -232,7 +232,7 @@ class EnumerateApplicationsOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::EnumerateApplications) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -274,7 +274,7 @@ class EnumerateProcessesOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::EnumerateProcesses) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -320,7 +320,7 @@ class SpawnOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::Spawn) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -379,7 +379,7 @@ class ResumeOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::Resume) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -422,7 +422,7 @@ class KillOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::Kill) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -468,7 +468,7 @@ class AttachOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::Attach) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();

--- a/src/device.cc
+++ b/src/device.cc
@@ -18,7 +18,6 @@ using v8::DEFAULT;
 using v8::Exception;
 using v8::External;
 using v8::Function;
-using v8::FunctionCallbackInfo;
 using v8::Handle;
 using v8::Integer;
 using v8::Isolate;
@@ -26,7 +25,6 @@ using v8::Local;
 using v8::Null;
 using v8::Object;
 using v8::Persistent;
-using v8::PropertyCallbackInfo;
 using v8::ReadOnly;
 using v8::String;
 using v8::Value;
@@ -88,7 +86,7 @@ Local<Object> Device::New(gpointer handle, Runtime* runtime) {
   return ctor->NewInstance(argc, argv);
 }
 
-void Device::New(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Device::New) {
   HandleScope();
 
   if (info.IsConstructCall()) {
@@ -112,8 +110,7 @@ void Device::New(const Nan::FunctionCallbackInfo<Value>& info) {
   }
 }
 
-void Device::GetId(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Device::GetId) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -124,8 +121,7 @@ void Device::GetId(Local<String> property,
       Integer::NewFromUnsigned(isolate, frida_device_get_id(handle)));
 }
 
-void Device::GetName(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Device::GetName) {
   HandleScope();
 
   auto handle = ObjectWrap::Unwrap<Device>(
@@ -135,8 +131,7 @@ void Device::GetName(Local<String> property,
       Nan::New(frida_device_get_name(handle)).ToLocalChecked());
 }
 
-void Device::GetIcon(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Device::GetIcon) {
   HandleScope();
 
   auto wrapper = ObjectWrap::Unwrap<Device>(info.Holder());
@@ -146,8 +141,7 @@ void Device::GetIcon(Local<String> property,
       wrapper->runtime_));
 }
 
-void Device::GetType(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Device::GetType) {
   HandleScope();
 
   auto handle = ObjectWrap::Unwrap<Device>(
@@ -195,7 +189,7 @@ class GetFrontmostApplicationOperation : public Operation<FridaDevice> {
   FridaApplication* application_;
 };
 
-void Device::GetFrontmostApplication(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Device::GetFrontmostApplication) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -237,7 +231,7 @@ class EnumerateApplicationsOperation : public Operation<FridaDevice> {
   FridaApplicationList* applications_;
 };
 
-void Device::EnumerateApplications(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Device::EnumerateApplications) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -279,7 +273,7 @@ class EnumerateProcessesOperation : public Operation<FridaDevice> {
   FridaProcessList* processes_;
 };
 
-void Device::EnumerateProcesses(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Device::EnumerateProcesses) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -325,7 +319,7 @@ class SpawnOperation : public Operation<FridaDevice> {
   guint pid_;
 };
 
-void Device::Spawn(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Device::Spawn) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -384,7 +378,7 @@ class ResumeOperation : public Operation<FridaDevice> {
   const guint pid_;
 };
 
-void Device::Resume(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Device::Resume) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -427,7 +421,7 @@ class KillOperation : public Operation<FridaDevice> {
   const guint pid_;
 };
 
-void Device::Kill(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Device::Kill) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -473,7 +467,7 @@ class AttachOperation : public Operation<FridaDevice> {
   FridaSession* session_;
 };
 
-void Device::Attach(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Device::Attach) {
   HandleScope();
 
   auto isolate = info.GetIsolate();

--- a/src/device.cc
+++ b/src/device.cc
@@ -83,7 +83,7 @@ Local<Object> Device::New(gpointer handle, Runtime* runtime) {
       runtime->GetDataPointer(DEVICE_DATA_CONSTRUCTOR)));
   const int argc = 1;
   Local<Value> argv[argc] = { External::New(isolate, handle) };
-  return ctor->NewInstance(argc, argv);
+  return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 
 NAN_METHOD(Device::New) {

--- a/src/device.h
+++ b/src/device.h
@@ -17,27 +17,21 @@ class Device : public GLibObject {
   Device(FridaDevice* handle, Runtime* runtime);
   ~Device();
 
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(New);
 
-  static void GetId(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetName(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetIcon(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetType(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
+  static NAN_PROPERTY_GETTER(GetId);
+  static NAN_PROPERTY_GETTER(GetName);
+  static NAN_PROPERTY_GETTER(GetIcon);
+  static NAN_PROPERTY_GETTER(GetType);
 
-  static void GetFrontmostApplication(
-      const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void EnumerateApplications(
-      const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void EnumerateProcesses(
-      const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void Spawn(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void Resume(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void Kill(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void Attach(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(GetFrontmostApplication);
+  static NAN_METHOD(EnumerateApplications);
+  static NAN_METHOD(EnumerateProcesses);
+
+  static NAN_METHOD(Spawn);
+  static NAN_METHOD(Resume);
+  static NAN_METHOD(Kill);
+  static NAN_METHOD(Attach);
 
   v8::Persistent<v8::Object> events_;
 };

--- a/src/device.h
+++ b/src/device.h
@@ -4,6 +4,7 @@
 #include "glib_object.h"
 
 #include <frida-core.h>
+#include <nan.h>
 
 namespace frida {
 
@@ -16,27 +17,27 @@ class Device : public GLibObject {
   Device(FridaDevice* handle, Runtime* runtime);
   ~Device();
 
-  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   static void GetId(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetName(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetIcon(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetType(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
 
   static void GetFrontmostApplication(
-      const v8::FunctionCallbackInfo<v8::Value>& args);
+      const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void EnumerateApplications(
-      const v8::FunctionCallbackInfo<v8::Value>& args);
+      const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void EnumerateProcesses(
-      const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Spawn(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Resume(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Kill(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Attach(const v8::FunctionCallbackInfo<v8::Value>& args);
+      const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void Spawn(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void Resume(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void Kill(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void Attach(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   v8::Persistent<v8::Object> events_;
 };

--- a/src/device_manager.cc
+++ b/src/device_manager.cc
@@ -10,12 +10,10 @@
 
 #define DEVICE_MANAGER_DATA_WRAPPERS "device_manager:wrappers"
 
-using v8::Array;
 using v8::Handle;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
-using v8::String;
 using v8::Value;
 using Nan::HandleScope;
 
@@ -40,11 +38,9 @@ DeviceManager::~DeviceManager() {
 }
 
 void DeviceManager::Init(Handle<Object> exports, Runtime* runtime) {
-  auto isolate = Isolate::GetCurrent();
-
   Local<v8::String> name = Nan::New("DeviceManager").ToLocalChecked();
 
-  auto tpl = CreateTemplate(isolate, name, DeviceManager::New, runtime);
+  auto tpl = CreateTemplate(name, DeviceManager::New, runtime);
 
   Nan::SetPrototypeMethod(tpl, "close", Close);
   Nan::SetPrototypeMethod(tpl, "enumerateDevices", EnumerateDevices);
@@ -99,7 +95,7 @@ class CloseOperation : public Operation<FridaDeviceManager> {
   }
 
   Local<Value> Result(Isolate* isolate) {
-    return Undefined(isolate);
+    return Nan::Undefined();
   }
 };
 
@@ -129,7 +125,7 @@ class EnumerateDevicesOperation : public Operation<FridaDeviceManager> {
 
   Local<Value> Result(Isolate* isolate) {
     auto size = frida_device_list_size(devices_);
-    auto devices = Array::New(isolate, size);
+    Local<v8::Array> devices = Nan::New<v8::Array>(size);
     for (auto i = 0; i != size; i++) {
       auto handle = frida_device_list_get(devices_, i);
       auto device = Device::New(handle, runtime_);

--- a/src/device_manager.cc
+++ b/src/device_manager.cc
@@ -11,7 +11,6 @@
 #define DEVICE_MANAGER_DATA_WRAPPERS "device_manager:wrappers"
 
 using v8::Array;
-using v8::FunctionCallbackInfo;
 using v8::Handle;
 using v8::Isolate;
 using v8::Local;
@@ -19,9 +18,6 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 using Nan::HandleScope;
-using Nan::New;
-using Nan::NewInstance;
-using Nan::Set;
 
 namespace frida {
 
@@ -67,7 +63,7 @@ void DeviceManager::Dispose(Runtime* runtime) {
   runtime->SetDataPointer(DEVICE_MANAGER_DATA_WRAPPERS, NULL);
 }
 
-void DeviceManager::New(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(DeviceManager::New) {
   HandleScope();
 
   if (info.IsConstructCall()) {
@@ -107,7 +103,7 @@ class CloseOperation : public Operation<FridaDeviceManager> {
   }
 };
 
-void DeviceManager::Close(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(DeviceManager::Close) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -149,7 +145,7 @@ class EnumerateDevicesOperation : public Operation<FridaDeviceManager> {
   FridaDeviceList* devices_;
 };
 
-void DeviceManager::EnumerateDevices(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(DeviceManager::EnumerateDevices) {
   HandleScope();
 
   auto isolate = info.GetIsolate();

--- a/src/device_manager.cc
+++ b/src/device_manager.cc
@@ -64,7 +64,7 @@ void DeviceManager::Dispose(Runtime* runtime) {
 }
 
 NAN_METHOD(DeviceManager::New) {
-  HandleScope();
+  HandleScope scope;
 
   if (info.IsConstructCall()) {
     auto runtime = GetRuntimeFromConstructorArgs(info);
@@ -104,7 +104,7 @@ class CloseOperation : public Operation<FridaDeviceManager> {
 };
 
 NAN_METHOD(DeviceManager::Close) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -146,7 +146,7 @@ class EnumerateDevicesOperation : public Operation<FridaDeviceManager> {
 };
 
 NAN_METHOD(DeviceManager::EnumerateDevices) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();

--- a/src/device_manager.h
+++ b/src/device_manager.h
@@ -16,10 +16,10 @@ class DeviceManager : public GLibObject {
   DeviceManager(FridaDeviceManager* handle, Runtime* runtime);
   ~DeviceManager();
 
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(New);
 
-  static void Close(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void EnumerateDevices(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(Close);
+  static NAN_METHOD(EnumerateDevices);
 
   static void OnListen(const gchar* signal, gpointer user_data);
   static void OnUnlisten(const gchar* signal, gpointer user_data);

--- a/src/device_manager.h
+++ b/src/device_manager.h
@@ -16,10 +16,10 @@ class DeviceManager : public GLibObject {
   DeviceManager(FridaDeviceManager* handle, Runtime* runtime);
   ~DeviceManager();
 
-  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
-  static void Close(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void EnumerateDevices(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Close(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void EnumerateDevices(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   static void OnListen(const gchar* signal, gpointer user_data);
   static void OnUnlisten(const gchar* signal, gpointer user_data);

--- a/src/events.cc
+++ b/src/events.cc
@@ -10,7 +10,6 @@ using v8::Boolean;
 using v8::Exception;
 using v8::External;
 using v8::Function;
-using v8::FunctionCallbackInfo;
 using v8::Handle;
 using v8::Integer;
 using v8::Isolate;
@@ -20,6 +19,7 @@ using v8::Object;
 using v8::Persistent;
 using v8::String;
 using v8::Value;
+using Nan::HandleScope;
 
 namespace frida {
 
@@ -30,8 +30,8 @@ struct _EventsClosure {
   gboolean alive;
   guint signal_id;
   guint handler_id;
-  Persistent<Function>* callback;
-  Persistent<Object>* parent;
+  v8::Persistent<Function>* callback;
+  v8::Persistent<Object>* parent;
   Events::TransformCallback transform;
   gpointer transform_data;
   Runtime* runtime;
@@ -69,16 +69,16 @@ Events::~Events() {
 void Events::Init(Handle<Object> exports, Runtime* runtime) {
   auto isolate = Isolate::GetCurrent();
 
-  auto name = NanNew("Events");
-  auto tpl = CreateTemplate(isolate, name, New, runtime);
+  auto name = Nan::New("Events").ToLocalChecked();
+  auto tpl = CreateTemplate(isolate, name, Events::New, runtime);
 
-  NODE_SET_PROTOTYPE_METHOD(tpl, "listen", Listen);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "unlisten", Unlisten);
+  Nan::SetPrototypeMethod(tpl, "listen", Listen);
+  Nan::SetPrototypeMethod(tpl, "unlisten", Unlisten);
 
-  auto ctor = tpl->GetFunction();
-  exports->Set(name, ctor);
+  auto ctor = Nan::GetFunction(tpl).ToLocalChecked();
+  Nan::Set(exports, name, ctor);
   runtime->SetDataPointer(EVENTS_DATA_CONSTRUCTOR,
-      new Persistent<Function>(isolate, ctor));
+      new v8::Persistent<Function>(isolate, ctor));
 }
 
 Local<Object> Events::New(gpointer handle, Runtime* runtime,
@@ -86,7 +86,7 @@ Local<Object> Events::New(gpointer handle, Runtime* runtime,
   auto isolate = Isolate::GetCurrent();
 
   auto ctor = Local<Function>::New(isolate,
-      *static_cast<Persistent<Function>*>(
+      *static_cast<v8::Persistent<Function>*>(
       runtime->GetDataPointer(EVENTS_DATA_CONSTRUCTOR)));
   const int argc = 3;
   Local<Value> argv[argc] = {
@@ -109,41 +109,41 @@ void Events::SetUnlistenCallback(UnlistenCallback callback,
   unlisten_data_ = user_data;
 }
 
-void Events::New(const FunctionCallbackInfo<Value>& args) {
-  NanScope();
+void Events::New(const Nan::FunctionCallbackInfo<Value>& info) {
+  HandleScope();
 
-  if (args.IsConstructCall()) {
-    if (args.Length() != 3 ||
-        !args[0]->IsExternal() ||
-        !args[1]->IsExternal() ||
-        !args[2]->IsExternal()) {
-      NanThrowTypeError("Bad argument, expected raw handles");
-      NanReturnUndefined();
+  if (info.IsConstructCall()) {
+    if (info.Length() != 3 ||
+        !info[0]->IsExternal() ||
+        !info[1]->IsExternal() ||
+        !info[2]->IsExternal()) {
+      Nan::ThrowTypeError("Bad argument, expected raw handles");
+      return;
     }
-    auto handle = Local<External>::Cast(args[0])->Value();
+    auto handle = Local<External>::Cast(info[0])->Value();
     auto transform = reinterpret_cast<TransformCallback>(
-        Local<External>::Cast(args[1])->Value());
-    auto transform_data = Local<External>::Cast(args[2])->Value();
+        Local<External>::Cast(info[1])->Value());
+    auto transform_data = Local<External>::Cast(info[2])->Value();
     auto wrapper = new Events(handle, transform, transform_data,
-        GetRuntimeFromConstructorArgs(args));
-    auto obj = args.This();
+        GetRuntimeFromConstructorArgs(info));
+    auto obj = info.This();
     wrapper->Wrap(obj);
-    NanReturnValue(obj);
+    info.GetReturnValue().Set(obj);
   } else {
-    NanReturnValue(args.Callee()->NewInstance(0, NULL));
+    info.GetReturnValue().Set(info.Callee()->NewInstance(0, NULL));
   }
 }
 
-void Events::Listen(const FunctionCallbackInfo<Value>& args) {
-  NanScope();
+void Events::Listen(const Nan::FunctionCallbackInfo<Value>& info) {
+  HandleScope();
 
-  auto obj = args.Holder();
+  auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Events>(obj);
   auto runtime = wrapper->runtime_;
 
   guint signal_id;
   Local<Function> callback;
-  if (!wrapper->GetSignalArguments(args, signal_id, callback))
+  if (!wrapper->GetSignalArguments(info, signal_id, callback))
     return;
 
   auto events_closure = events_closure_new(signal_id, callback, obj,
@@ -164,15 +164,15 @@ void Events::Listen(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-void Events::Unlisten(const FunctionCallbackInfo<Value>& args) {
-  NanScope();
+void Events::Unlisten(const Nan::FunctionCallbackInfo<Value>& info) {
+  HandleScope();
 
-  auto isolate = args.GetIsolate();
-  auto wrapper = ObjectWrap::Unwrap<Events>(args.Holder());
+  auto isolate = info.GetIsolate();
+  auto wrapper = ObjectWrap::Unwrap<Events>(info.Holder());
 
   guint signal_id;
   Local<Function> callback;
-  if (!wrapper->GetSignalArguments(args, signal_id, callback))
+  if (!wrapper->GetSignalArguments(info, signal_id, callback))
     return;
 
   for (GSList* cur = wrapper->closures_; cur != NULL; cur = cur->next) {
@@ -205,19 +205,19 @@ void Events::Unlisten(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-bool Events::GetSignalArguments(const FunctionCallbackInfo<Value>& args,
+bool Events::GetSignalArguments(const Nan::FunctionCallbackInfo<Value>& info,
     guint& signal_id, Local<Function>& callback) {
-  if (args.Length() < 2 || !args[0]->IsString() || !args[1]->IsFunction()) {
-    NanThrowTypeError("Bad arguments, expected string and function");
+  if (info.Length() < 2 || !info[0]->IsString() || !info[1]->IsFunction()) {
+    Nan::ThrowTypeError("Bad arguments, expected string and function");
     return false;
   }
-  String::Utf8Value signal_name(Local<String>::Cast(args[0]));
+  String::Utf8Value signal_name(Local<String>::Cast(info[0]));
   signal_id = g_signal_lookup(*signal_name, G_OBJECT_TYPE(handle_));
   if (signal_id == 0) {
-    NanThrowTypeError("Bad event name");
+    Nan::ThrowTypeError("Bad event name");
     return false;
   }
-  callback = Local<Function>::Cast(args[1]);
+  callback = Local<Function>::Cast(info[1]);
   return true;
 }
 
@@ -235,8 +235,8 @@ static EventsClosure* events_closure_new(guint signal_id,
   self->alive = TRUE;
   self->signal_id = signal_id;
   self->handler_id = 0;
-  self->callback = new Persistent<Function>(isolate, callback);
-  self->parent = new Persistent<Object>(isolate, parent);
+  self->callback = new v8::Persistent<Function>(isolate, callback);
+  self->parent = new v8::Persistent<Object>(isolate, parent);
   self->transform = transform;
   self->transform_data = transform_data;
   self->runtime = runtime;
@@ -330,14 +330,15 @@ static Local<Value> events_closure_gvalue_to_jsvalue(Isolate* isolate,
     case G_TYPE_DOUBLE:
       return Number::New(isolate, g_value_get_double(gvalue));
     case G_TYPE_STRING:
-      return NanNew(g_value_get_string(gvalue));
+      return Nan::New(g_value_get_string(gvalue)).ToLocalChecked();
     case G_TYPE_VARIANT: {
       auto variant = g_value_get_variant (gvalue);
       g_assert(variant != NULL);
       g_assert(g_variant_is_of_type(variant, G_VARIANT_TYPE("ay")));
-      return NanNewBufferHandle(
-        reinterpret_cast<const char*>(g_variant_get_data(variant)),
-        g_variant_get_size(variant));
+      return Nan::NewBuffer(
+        reinterpret_cast<char*>(const_cast<void*>(g_variant_get_data(
+          variant))),
+        g_variant_get_size(variant)).ToLocalChecked();
     }
     default:
       g_assert_not_reached();

--- a/src/events.cc
+++ b/src/events.cc
@@ -109,7 +109,7 @@ void Events::SetUnlistenCallback(UnlistenCallback callback,
   unlisten_data_ = user_data;
 }
 
-void Events::New(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Events::New) {
   HandleScope();
 
   if (info.IsConstructCall()) {
@@ -134,7 +134,7 @@ void Events::New(const Nan::FunctionCallbackInfo<Value>& info) {
   }
 }
 
-void Events::Listen(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Events::Listen) {
   HandleScope();
 
   auto obj = info.Holder();
@@ -164,7 +164,7 @@ void Events::Listen(const Nan::FunctionCallbackInfo<Value>& info) {
   }
 }
 
-void Events::Unlisten(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Events::Unlisten) {
   HandleScope();
 
   auto isolate = info.GetIsolate();

--- a/src/events.cc
+++ b/src/events.cc
@@ -110,7 +110,7 @@ void Events::SetUnlistenCallback(UnlistenCallback callback,
 }
 
 NAN_METHOD(Events::New) {
-  HandleScope();
+  HandleScope scope;
 
   if (info.IsConstructCall()) {
     if (info.Length() != 3 ||
@@ -135,7 +135,7 @@ NAN_METHOD(Events::New) {
 }
 
 NAN_METHOD(Events::Listen) {
-  HandleScope();
+  HandleScope scope;
 
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Events>(obj);
@@ -165,7 +165,7 @@ NAN_METHOD(Events::Listen) {
 }
 
 NAN_METHOD(Events::Unlisten) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto wrapper = ObjectWrap::Unwrap<Events>(info.Holder());

--- a/src/events.cc
+++ b/src/events.cc
@@ -94,7 +94,7 @@ Local<Object> Events::New(gpointer handle, Runtime* runtime,
     External::New(isolate, reinterpret_cast<void*>(transform)),
     External::New(isolate, transform_data)
   };
-  return ctor->NewInstance(argc, argv);
+  return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 
 void Events::SetListenCallback(ListenCallback callback,

--- a/src/events.h
+++ b/src/events.h
@@ -24,13 +24,13 @@ class Events : public GLibObject {
       Runtime* runtime);
   ~Events();
 
-  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
-  static void Listen(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Unlisten(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Listen(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void Unlisten(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   bool GetSignalArguments(
-      const v8::FunctionCallbackInfo<v8::Value>& args,
+      const Nan::FunctionCallbackInfo<v8::Value>& info,
       guint& signal_id, v8::Local<v8::Function>& callback);
 
   TransformCallback transform_;

--- a/src/events.h
+++ b/src/events.h
@@ -24,10 +24,10 @@ class Events : public GLibObject {
       Runtime* runtime);
   ~Events();
 
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(New);
 
-  static void Listen(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void Unlisten(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(Listen);
+  static NAN_METHOD(Unlisten);
 
   bool GetSignalArguments(
       const Nan::FunctionCallbackInfo<v8::Value>& info,

--- a/src/events.h
+++ b/src/events.h
@@ -7,8 +7,8 @@ namespace frida {
 
 class Events : public GLibObject {
  public:
-  typedef v8::Local<v8::Value>(*TransformCallback)(v8::Isolate* isolate,
-      const gchar* name, guint index, const GValue* value, gpointer user_data);
+  typedef v8::Local<v8::Value>(*TransformCallback)(const gchar* name,
+      guint index, const GValue* value, gpointer user_data);
   typedef void (*ListenCallback)(const gchar* signal, gpointer user_data);
   typedef void (*UnlistenCallback)(const gchar* signal, gpointer user_data);
 

--- a/src/glib_object.cc
+++ b/src/glib_object.cc
@@ -1,5 +1,7 @@
 #include "glib_object.h"
 
+#include <nan.h>
+
 using v8::External;
 using v8::FunctionCallback;
 using v8::FunctionCallbackInfo;
@@ -13,16 +15,16 @@ using v8::Value;
 namespace frida {
 
 Local<FunctionTemplate> GLibObject::CreateTemplate(Isolate* isolate,
-    Handle<String> name, FunctionCallback callback, Runtime* runtime) {
-  auto tpl = FunctionTemplate::New(isolate, callback,
-      External::New(isolate, runtime));
+    Local<String> name, Nan::FunctionCallback callback, Runtime* runtime) {
+  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(
+    callback, External::New(isolate, runtime));
   tpl->SetClassName(name);
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   return tpl;
 }
 
 Runtime* GLibObject::GetRuntimeFromConstructorArgs(
-    const FunctionCallbackInfo<Value>& args) {
+    const Nan::FunctionCallbackInfo<Value>& args) {
   return static_cast<Runtime*>(args.Data().As<External>()->Value ());
 }
 

--- a/src/glib_object.cc
+++ b/src/glib_object.cc
@@ -3,21 +3,17 @@
 #include <nan.h>
 
 using v8::External;
-using v8::FunctionCallback;
-using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
-using v8::Isolate;
 using v8::Local;
 using v8::String;
 using v8::Value;
 
 namespace frida {
 
-Local<FunctionTemplate> GLibObject::CreateTemplate(Isolate* isolate,
-    Local<String> name, Nan::FunctionCallback callback, Runtime* runtime) {
+Local<FunctionTemplate> GLibObject::CreateTemplate(Local<String> name,
+    Nan::FunctionCallback callback, Runtime* runtime) {
   v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(
-    callback, External::New(isolate, runtime));
+    callback, Nan::New<v8::External>(runtime));
   tpl->SetClassName(name);
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   return tpl;

--- a/src/glib_object.h
+++ b/src/glib_object.h
@@ -4,6 +4,7 @@
 #include "runtime.h"
 
 #include <glib.h>
+#include <nan.h>
 #include <node_object_wrap.h>
 
 namespace frida {
@@ -16,10 +17,10 @@ class GLibObject : public node::ObjectWrap {
   }
 
   static v8::Local<v8::FunctionTemplate> CreateTemplate(v8::Isolate* isolate,
-      v8::Handle<v8::String> name, v8::FunctionCallback callback,
+      v8::Local<v8::String> name, Nan::FunctionCallback callback,
       Runtime* runtime);
   static Runtime* GetRuntimeFromConstructorArgs(
-      const v8::FunctionCallbackInfo<v8::Value>& args);
+      const Nan::FunctionCallbackInfo<v8::Value>& info);
 
  public:
   template<typename T>

--- a/src/glib_object.h
+++ b/src/glib_object.h
@@ -16,9 +16,8 @@ class GLibObject : public node::ObjectWrap {
       runtime_(runtime) {
   }
 
-  static v8::Local<v8::FunctionTemplate> CreateTemplate(v8::Isolate* isolate,
-      v8::Local<v8::String> name, Nan::FunctionCallback callback,
-      Runtime* runtime);
+  static v8::Local<v8::FunctionTemplate> CreateTemplate(v8::Local<v8::String> name,
+      Nan::FunctionCallback callback, Runtime* runtime);
   static Runtime* GetRuntimeFromConstructorArgs(
       const Nan::FunctionCallbackInfo<v8::Value>& info);
 

--- a/src/icon.cc
+++ b/src/icon.cc
@@ -73,7 +73,7 @@ Local<Value> Icon::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Icon::New) {
-  HandleScope();
+  HandleScope scope;
 
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
@@ -95,7 +95,7 @@ NAN_METHOD(Icon::New) {
 }
 
 NAN_PROPERTY_GETTER(Icon::GetWidth) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Icon>(
@@ -106,7 +106,7 @@ NAN_PROPERTY_GETTER(Icon::GetWidth) {
 }
 
 NAN_PROPERTY_GETTER(Icon::GetHeight) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Icon>(
@@ -117,7 +117,7 @@ NAN_PROPERTY_GETTER(Icon::GetHeight) {
 }
 
 NAN_PROPERTY_GETTER(Icon::GetRowstride) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Icon>(
@@ -128,7 +128,7 @@ NAN_PROPERTY_GETTER(Icon::GetRowstride) {
 }
 
 NAN_PROPERTY_GETTER(Icon::GetPixels) {
-  HandleScope();
+  HandleScope scope;
 
   auto handle = ObjectWrap::Unwrap<Icon>(
       info.Holder())->GetHandle<FridaIcon>();

--- a/src/icon.cc
+++ b/src/icon.cc
@@ -72,7 +72,7 @@ Local<Value> Icon::New(gpointer handle, Runtime* runtime) {
   return ctor->NewInstance(argc, argv);
 }
 
-void Icon::New(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Icon::New) {
   HandleScope();
 
   if (info.IsConstructCall()) {
@@ -94,8 +94,7 @@ void Icon::New(const Nan::FunctionCallbackInfo<Value>& info) {
   }
 }
 
-void Icon::GetWidth(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Icon::GetWidth) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -106,8 +105,7 @@ void Icon::GetWidth(Local<String> property,
       Integer::New(isolate, frida_icon_get_width(handle)));
 }
 
-void Icon::GetHeight(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Icon::GetHeight) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -118,8 +116,7 @@ void Icon::GetHeight(Local<String> property,
       Integer::New(isolate, frida_icon_get_height(handle)));
 }
 
-void Icon::GetRowstride(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Icon::GetRowstride) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -130,8 +127,7 @@ void Icon::GetRowstride(Local<String> property,
       Integer::New(isolate, frida_icon_get_rowstride(handle)));
 }
 
-void Icon::GetPixels(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Icon::GetPixels) {
   HandleScope();
 
   auto handle = ObjectWrap::Unwrap<Icon>(

--- a/src/icon.cc
+++ b/src/icon.cc
@@ -7,8 +7,6 @@
 
 using v8::AccessorSignature;
 using v8::DEFAULT;
-using v8::DontEnum;
-using v8::Exception;
 using v8::External;
 using v8::Function;
 using v8::Handle;
@@ -16,10 +14,7 @@ using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
-using v8::Persistent;
-using v8::PropertyAttribute;
 using v8::ReadOnly;
-using v8::String;
 using v8::Value;
 using Nan::HandleScope;
 
@@ -38,7 +33,7 @@ void Icon::Init(Handle<Object> exports, Runtime* runtime) {
   auto isolate = Isolate::GetCurrent();
 
   auto name = Nan::New("Icon").ToLocalChecked();
-  auto tpl = CreateTemplate(isolate, name, New, runtime);
+  auto tpl = CreateTemplate(name, New, runtime);
 
   auto instance_tpl = tpl->InstanceTemplate();
   auto data = Handle<Value>();
@@ -59,16 +54,14 @@ void Icon::Init(Handle<Object> exports, Runtime* runtime) {
 }
 
 Local<Value> Icon::New(gpointer handle, Runtime* runtime) {
-  auto isolate = Isolate::GetCurrent();
-
   if (handle == NULL)
-    return Null(isolate);
+    return Nan::Null();
 
-  auto ctor = Local<Function>::New(isolate,
+  auto ctor = Nan::New<Function>(
       *static_cast<v8::Persistent<Function>*>(
       runtime->GetDataPointer(ICON_DATA_CONSTRUCTOR)));
   const int argc = 1;
-  Local<Value> argv[argc] = { External::New(isolate, handle) };
+  Local<Value> argv[argc] = { Nan::New<v8::External>(handle) };
   return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 
@@ -97,34 +90,31 @@ NAN_METHOD(Icon::New) {
 NAN_PROPERTY_GETTER(Icon::GetWidth) {
   HandleScope scope;
 
-  auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Icon>(
       info.Holder())->GetHandle<FridaIcon>();
 
-  info.GetReturnValue().Set(
-      Integer::New(isolate, frida_icon_get_width(handle)));
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(
+    frida_icon_get_width(handle)));
 }
 
 NAN_PROPERTY_GETTER(Icon::GetHeight) {
   HandleScope scope;
 
-  auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Icon>(
       info.Holder())->GetHandle<FridaIcon>();
 
-  info.GetReturnValue().Set(
-      Integer::New(isolate, frida_icon_get_height(handle)));
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(
+    frida_icon_get_height(handle)));
 }
 
 NAN_PROPERTY_GETTER(Icon::GetRowstride) {
   HandleScope scope;
 
-  auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Icon>(
       info.Holder())->GetHandle<FridaIcon>();
 
-  info.GetReturnValue().Set(
-      Integer::New(isolate, frida_icon_get_rowstride(handle)));
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(
+    frida_icon_get_rowstride(handle)));
 }
 
 NAN_PROPERTY_GETTER(Icon::GetPixels) {

--- a/src/icon.cc
+++ b/src/icon.cc
@@ -69,7 +69,7 @@ Local<Value> Icon::New(gpointer handle, Runtime* runtime) {
       runtime->GetDataPointer(ICON_DATA_CONSTRUCTOR)));
   const int argc = 1;
   Local<Value> argv[argc] = { External::New(isolate, handle) };
-  return ctor->NewInstance(argc, argv);
+  return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 
 NAN_METHOD(Icon::New) {

--- a/src/icon.h
+++ b/src/icon.h
@@ -4,6 +4,7 @@
 #include "glib_object.h"
 
 #include <frida-core.h>
+#include <nan.h>
 
 namespace frida {
 
@@ -16,16 +17,16 @@ class Icon : public GLibObject {
   explicit Icon(FridaIcon* handle, Runtime* runtime);
   ~Icon();
 
-  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   static void GetWidth(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetHeight(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetRowstride(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetPixels(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
 };
 
 }

--- a/src/icon.h
+++ b/src/icon.h
@@ -17,16 +17,13 @@ class Icon : public GLibObject {
   explicit Icon(FridaIcon* handle, Runtime* runtime);
   ~Icon();
 
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(New);
 
-  static void GetWidth(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetHeight(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetRowstride(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetPixels(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
+  static NAN_PROPERTY_GETTER(GetWidth);
+  static NAN_PROPERTY_GETTER(GetHeight);
+  static NAN_PROPERTY_GETTER(GetRowstride);
+  static NAN_PROPERTY_GETTER(GetPixels);
+
 };
 
 }

--- a/src/operation.h
+++ b/src/operation.h
@@ -62,7 +62,7 @@ class Operation {
     if (error_ == NULL) {
       resolver->Resolve(Result(isolate));
     } else {
-      resolver->Reject(v8::Exception::Error(NanNew(error_->message)));
+      resolver->Reject(Nan::Error(error_->message));
     }
     runtime_->GetUVContext()->DecreaseUsage();
     delete this;

--- a/src/process.cc
+++ b/src/process.cc
@@ -65,7 +65,7 @@ Local<Object> Process::New(gpointer handle, Runtime* runtime) {
       runtime->GetDataPointer(PROCESS_DATA_CONSTRUCTOR)));
   const int argc = 1;
   Local<Value> argv[argc] = { External::New(isolate, handle) };
-  return ctor->NewInstance(argc, argv);
+  return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 
 NAN_METHOD(Process::New) {

--- a/src/process.cc
+++ b/src/process.cc
@@ -8,17 +8,13 @@
 
 using v8::AccessorSignature;
 using v8::DEFAULT;
-using v8::Exception;
 using v8::External;
 using v8::Function;
 using v8::Handle;
-using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
-using v8::Persistent;
 using v8::ReadOnly;
-using v8::String;
 using v8::Value;
 using Nan::HandleScope;
 
@@ -37,7 +33,7 @@ void Process::Init(Handle<Object> exports, Runtime* runtime) {
   auto isolate = Isolate::GetCurrent();
 
   auto name = Nan::New("Process").ToLocalChecked();
-  auto tpl = CreateTemplate(isolate, name, Process::New, runtime);
+  auto tpl = CreateTemplate(name, Process::New, runtime);
 
   auto instance_tpl = tpl->InstanceTemplate();
   auto data = Handle<Value>();
@@ -58,13 +54,11 @@ void Process::Init(Handle<Object> exports, Runtime* runtime) {
 }
 
 Local<Object> Process::New(gpointer handle, Runtime* runtime) {
-  auto isolate = Isolate::GetCurrent();
-
-  auto ctor = Local<Function>::New(isolate,
+  auto ctor = Nan::New<Function>(
       *static_cast<v8::Persistent<Function>*>(
       runtime->GetDataPointer(PROCESS_DATA_CONSTRUCTOR)));
   const int argc = 1;
-  Local<Value> argv[argc] = { External::New(isolate, handle) };
+  Local<Value> argv[argc] = { Nan::New<v8::External>(handle) };
   return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 
@@ -93,12 +87,11 @@ NAN_METHOD(Process::New) {
 NAN_PROPERTY_GETTER(Process::GetPid) {
   HandleScope scope;
 
-  auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Process>(
       info.Holder())->GetHandle<FridaProcess>();
 
-  info.GetReturnValue().Set(
-      Integer::New(isolate, frida_process_get_pid(handle)));
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(
+      frida_process_get_pid(handle)));
 }
 
 NAN_PROPERTY_GETTER(Process::GetName) {

--- a/src/process.cc
+++ b/src/process.cc
@@ -68,7 +68,7 @@ Local<Object> Process::New(gpointer handle, Runtime* runtime) {
   return ctor->NewInstance(argc, argv);
 }
 
-void Process::New(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Process::New) {
   HandleScope();
 
   if (info.IsConstructCall()) {
@@ -90,8 +90,7 @@ void Process::New(const Nan::FunctionCallbackInfo<Value>& info) {
   }
 }
 
-void Process::GetPid(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Process::GetPid) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -102,8 +101,7 @@ void Process::GetPid(Local<String> property,
       Integer::New(isolate, frida_process_get_pid(handle)));
 }
 
-void Process::GetName(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Process::GetName) {
   HandleScope();
 
   auto handle = ObjectWrap::Unwrap<Process>(
@@ -113,8 +111,7 @@ void Process::GetName(Local<String> property,
       Nan::New(frida_process_get_name(handle)).ToLocalChecked());
 }
 
-void Process::GetSmallIcon(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Process::GetSmallIcon) {
   HandleScope();
 
   auto wrapper = ObjectWrap::Unwrap<Process>(info.Holder());
@@ -124,8 +121,7 @@ void Process::GetSmallIcon(Local<String> property,
       Icon::New(frida_process_get_small_icon(handle), wrapper->runtime_));
 }
 
-void Process::GetLargeIcon(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Process::GetLargeIcon) {
   HandleScope();
 
   auto wrapper = ObjectWrap::Unwrap<Process>(info.Holder());

--- a/src/process.cc
+++ b/src/process.cc
@@ -69,7 +69,7 @@ Local<Object> Process::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Process::New) {
-  HandleScope();
+  HandleScope scope;
 
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
@@ -91,7 +91,7 @@ NAN_METHOD(Process::New) {
 }
 
 NAN_PROPERTY_GETTER(Process::GetPid) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Process>(
@@ -102,7 +102,7 @@ NAN_PROPERTY_GETTER(Process::GetPid) {
 }
 
 NAN_PROPERTY_GETTER(Process::GetName) {
-  HandleScope();
+  HandleScope scope;
 
   auto handle = ObjectWrap::Unwrap<Process>(
       info.Holder())->GetHandle<FridaProcess>();
@@ -112,7 +112,7 @@ NAN_PROPERTY_GETTER(Process::GetName) {
 }
 
 NAN_PROPERTY_GETTER(Process::GetSmallIcon) {
-  HandleScope();
+  HandleScope scope;
 
   auto wrapper = ObjectWrap::Unwrap<Process>(info.Holder());
   auto handle = wrapper->GetHandle<FridaProcess>();
@@ -122,7 +122,7 @@ NAN_PROPERTY_GETTER(Process::GetSmallIcon) {
 }
 
 NAN_PROPERTY_GETTER(Process::GetLargeIcon) {
-  HandleScope();
+  HandleScope scope;
 
   auto wrapper = ObjectWrap::Unwrap<Process>(info.Holder());
   auto handle = wrapper->GetHandle<FridaProcess>();

--- a/src/process.cc
+++ b/src/process.cc
@@ -11,17 +11,16 @@ using v8::DEFAULT;
 using v8::Exception;
 using v8::External;
 using v8::Function;
-using v8::FunctionCallbackInfo;
 using v8::Handle;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
 using v8::Persistent;
-using v8::PropertyCallbackInfo;
 using v8::ReadOnly;
 using v8::String;
 using v8::Value;
+using Nan::HandleScope;
 
 namespace frida {
 
@@ -37,102 +36,102 @@ Process::~Process() {
 void Process::Init(Handle<Object> exports, Runtime* runtime) {
   auto isolate = Isolate::GetCurrent();
 
-  auto name = NanNew("Process");
-  auto tpl = CreateTemplate(isolate, name, New, runtime);
+  auto name = Nan::New("Process").ToLocalChecked();
+  auto tpl = CreateTemplate(isolate, name, Process::New, runtime);
 
   auto instance_tpl = tpl->InstanceTemplate();
   auto data = Handle<Value>();
   auto signature = AccessorSignature::New(isolate, tpl);
-  instance_tpl->SetAccessor(NanNew("pid"),
+  Nan::SetAccessor(instance_tpl, Nan::New("pid").ToLocalChecked(),
       GetPid, 0, data, DEFAULT, ReadOnly, signature);
-  instance_tpl->SetAccessor(NanNew("name"),
+  Nan::SetAccessor(instance_tpl, Nan::New("name").ToLocalChecked(),
       GetName, 0, data, DEFAULT, ReadOnly, signature);
-  instance_tpl->SetAccessor(NanNew("smallIcon"),
+  Nan::SetAccessor(instance_tpl, Nan::New("smallIcon").ToLocalChecked(),
       GetSmallIcon, 0, data, DEFAULT, ReadOnly, signature);
-  instance_tpl->SetAccessor(NanNew("largeIcon"),
+  Nan::SetAccessor(instance_tpl, Nan::New("largeIcon").ToLocalChecked(),
       GetLargeIcon, 0, data, DEFAULT, ReadOnly, signature);
 
-  auto ctor = tpl->GetFunction();
-  exports->Set(name, ctor);
+  auto ctor = Nan::GetFunction(tpl).ToLocalChecked();
+  Nan::Set(exports, name, ctor);
   runtime->SetDataPointer(PROCESS_DATA_CONSTRUCTOR,
-      new Persistent<Function>(isolate, ctor));
+      new v8::Persistent<Function>(isolate, ctor));
 }
 
 Local<Object> Process::New(gpointer handle, Runtime* runtime) {
   auto isolate = Isolate::GetCurrent();
 
   auto ctor = Local<Function>::New(isolate,
-      *static_cast<Persistent<Function>*>(
+      *static_cast<v8::Persistent<Function>*>(
       runtime->GetDataPointer(PROCESS_DATA_CONSTRUCTOR)));
   const int argc = 1;
   Local<Value> argv[argc] = { External::New(isolate, handle) };
   return ctor->NewInstance(argc, argv);
 }
 
-void Process::New(const FunctionCallbackInfo<Value>& args) {
-  NanScope();
+void Process::New(const Nan::FunctionCallbackInfo<Value>& info) {
+  HandleScope();
 
-  if (args.IsConstructCall()) {
-    if (args.Length() != 1 || !args[0]->IsExternal()) {
-      NanThrowTypeError("Bad argument, expected raw handle");
-      NanReturnUndefined();
+  if (info.IsConstructCall()) {
+    if (info.Length() != 1 || !info[0]->IsExternal()) {
+      Nan::ThrowTypeError("Bad argument, expected raw handle");
+      return;
     }
-    auto runtime = GetRuntimeFromConstructorArgs(args);
+    auto runtime = GetRuntimeFromConstructorArgs(info);
 
     auto handle = static_cast<FridaProcess*>(
-        Local<External>::Cast(args[0])->Value());
+        Local<External>::Cast(info[0])->Value());
     auto wrapper = new Process(handle, runtime);
-    auto obj = args.This();
+    auto obj = info.This();
     wrapper->Wrap(obj);
 
-    NanReturnValue(obj);
+    info.GetReturnValue().Set(obj);
   } else {
-    NanReturnValue(args.Callee()->NewInstance(0, NULL));
+    info.GetReturnValue().Set(info.Callee()->NewInstance(0, NULL));
   }
 }
 
 void Process::GetPid(Local<String> property,
-    const PropertyCallbackInfo<Value>& args) {
-  NanScope();
+    const Nan::PropertyCallbackInfo<Value>& info) {
+  HandleScope();
 
-  auto isolate = args.GetIsolate();
+  auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Process>(
-      args.Holder())->GetHandle<FridaProcess>();
+      info.Holder())->GetHandle<FridaProcess>();
 
-  NanReturnValue(
+  info.GetReturnValue().Set(
       Integer::New(isolate, frida_process_get_pid(handle)));
 }
 
 void Process::GetName(Local<String> property,
-    const PropertyCallbackInfo<Value>& args) {
-  NanScope();
+    const Nan::PropertyCallbackInfo<Value>& info) {
+  HandleScope();
 
   auto handle = ObjectWrap::Unwrap<Process>(
-      args.Holder())->GetHandle<FridaProcess>();
+      info.Holder())->GetHandle<FridaProcess>();
 
-  NanReturnValue(
-      NanNew(frida_process_get_name(handle)));
+  info.GetReturnValue().Set(
+      Nan::New(frida_process_get_name(handle)).ToLocalChecked());
 }
 
 void Process::GetSmallIcon(Local<String> property,
-    const PropertyCallbackInfo<Value>& args) {
-  NanScope();
+    const Nan::PropertyCallbackInfo<Value>& info) {
+  HandleScope();
 
-  auto wrapper = ObjectWrap::Unwrap<Process>(args.Holder());
+  auto wrapper = ObjectWrap::Unwrap<Process>(info.Holder());
   auto handle = wrapper->GetHandle<FridaProcess>();
 
-  NanReturnValue(
+  info.GetReturnValue().Set(
       Icon::New(frida_process_get_small_icon(handle), wrapper->runtime_));
 }
 
 void Process::GetLargeIcon(Local<String> property,
-    const PropertyCallbackInfo<Value>& args) {
-  NanScope();
+    const Nan::PropertyCallbackInfo<Value>& info) {
+  HandleScope();
 
-  auto wrapper = ObjectWrap::Unwrap<Process>(args.Holder());
+  auto wrapper = ObjectWrap::Unwrap<Process>(info.Holder());
   auto handle = wrapper->GetHandle<FridaProcess>();
 
-  NanReturnValue(
+  info.GetReturnValue().Set(
       Icon::New(frida_process_get_large_icon(handle), wrapper->runtime_));
 }
 

--- a/src/process.h
+++ b/src/process.h
@@ -16,16 +16,16 @@ class Process : public GLibObject {
   explicit Process(FridaProcess* handle, Runtime* runtime);
   ~Process();
 
-  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   static void GetPid(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetName(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetSmallIcon(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
   static void GetLargeIcon(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
 };
 
 }

--- a/src/process.h
+++ b/src/process.h
@@ -16,16 +16,12 @@ class Process : public GLibObject {
   explicit Process(FridaProcess* handle, Runtime* runtime);
   ~Process();
 
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(New);
 
-  static void GetPid(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetName(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetSmallIcon(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
-  static void GetLargeIcon(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
+  static NAN_PROPERTY_GETTER(GetPid);
+  static NAN_PROPERTY_GETTER(GetName);
+  static NAN_PROPERTY_GETTER(GetSmallIcon);
+  static NAN_PROPERTY_GETTER(GetLargeIcon);
 };
 
 }

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -58,16 +58,16 @@ void Runtime::SetDataPointer(const char* id, void* value) {
   g_hash_table_insert(data_, const_cast<char*>(id), value);
 }
 
-Local<String> Runtime::ValueToJson(Isolate* isolate, Handle<Value> value) {
-  auto module = Local<Object>::New(isolate, json_module_);
-  auto stringify = Local<Function>::New(isolate, json_stringify_);
+Local<String> Runtime::ValueToJson(Handle<Value> value) {
+  auto module = Nan::New<v8::Object>(json_module_);
+  auto stringify = Nan::New<v8::Function>(json_stringify_);
   Local<Value> argv[] = { value };
   return Local<String>::Cast(stringify->Call(module, 1, argv));
 }
 
-Local<Value> Runtime::ValueFromJson(Isolate* isolate, Handle<String> json) {
-  auto module = Local<Object>::New(isolate, json_module_);
-  auto parse = Local<Function>::New(isolate, json_parse_);
+Local<Value> Runtime::ValueFromJson(Handle<String> json) {
+  auto module = Nan::New<v8::Object>(json_module_);
+  auto parse = Nan::New<v8::Function>(json_parse_);
   Local<Value> argv[] = { json };
   return parse->Call(module, 1, argv);
 }

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -19,11 +19,13 @@ Runtime::Runtime(UVContext* uv_context, GLibContext* glib_context)
   auto isolate = Isolate::GetCurrent();
   auto global = isolate->GetCurrentContext()->Global();
   auto json_module = Local<Object>::Cast(
-      global->Get(NanNew("JSON")));
+      Nan::Get(global, Nan::New("JSON").ToLocalChecked()).ToLocalChecked());
   auto json_stringify = Local<Function>::Cast(
-      json_module->Get(NanNew("stringify")));
+      Nan::Get(json_module,
+        Nan::New("stringify").ToLocalChecked()).ToLocalChecked());
   auto json_parse = Local<Function>::Cast(
-      json_module->Get(NanNew("parse")));
+      Nan::Get(json_module,
+        Nan::New("parse").ToLocalChecked()).ToLocalChecked());
   json_module_.Reset(isolate, json_module);
   json_stringify_.Reset(isolate, json_stringify);
   json_parse_.Reset(isolate, json_parse);

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -19,10 +19,8 @@ class Runtime {
   void* GetDataPointer(const char* id);
   void SetDataPointer(const char* id, void* value);
 
-  v8::Local<v8::String> ValueToJson(v8::Isolate* isolate,
-      v8::Handle<v8::Value> value);
-  v8::Local<v8::Value> ValueFromJson(v8::Isolate* isolate,
-      v8::Handle<v8::String> json);
+  v8::Local<v8::String> ValueToJson(v8::Handle<v8::Value> value);
+  v8::Local<v8::Value> ValueFromJson(v8::Handle<v8::String> json);
 
  private:
   UVContext* uv_context_;

--- a/src/script.cc
+++ b/src/script.cc
@@ -61,7 +61,7 @@ Local<Object> Script::New(gpointer handle, Runtime* runtime) {
   return ctor->NewInstance(argc, argv);
 }
 
-void Script::New(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Script::New) {
   HandleScope();
 
   if (info.IsConstructCall()) {
@@ -104,7 +104,7 @@ class LoadOperation : public Operation<FridaScript> {
   }
 };
 
-void Script::Load(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Script::Load) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -132,7 +132,7 @@ class UnloadOperation : public Operation<FridaScript> {
   }
 };
 
-void Script::Unload(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Script::Unload) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -169,7 +169,7 @@ class PostMessageOperation : public Operation<FridaScript> {
   gchar* message_;
 };
 
-void Script::PostMessage(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Script::PostMessage) {
   HandleScope();
 
   auto isolate = info.GetIsolate();

--- a/src/script.cc
+++ b/src/script.cc
@@ -58,7 +58,7 @@ Local<Object> Script::New(gpointer handle, Runtime* runtime) {
       runtime->GetDataPointer(SCRIPT_DATA_CONSTRUCTOR)));
   const int argc = 1;
   Local<Value> argv[argc] = { External::New(isolate, handle) };
-  return ctor->NewInstance(argc, argv);
+  return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 
 NAN_METHOD(Script::New) {

--- a/src/script.cc
+++ b/src/script.cc
@@ -62,7 +62,7 @@ Local<Object> Script::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Script::New) {
-  HandleScope();
+  HandleScope scope;
 
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
@@ -105,7 +105,7 @@ class LoadOperation : public Operation<FridaScript> {
 };
 
 NAN_METHOD(Script::Load) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -133,7 +133,7 @@ class UnloadOperation : public Operation<FridaScript> {
 };
 
 NAN_METHOD(Script::Unload) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -170,7 +170,7 @@ class PostMessageOperation : public Operation<FridaScript> {
 };
 
 NAN_METHOD(Script::PostMessage) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();

--- a/src/script.h
+++ b/src/script.h
@@ -17,11 +17,11 @@ class Script : public GLibObject {
   explicit Script(FridaScript* handle, Runtime* runtime);
   ~Script();
 
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(New);
 
-  static void Load(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void Unload(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void PostMessage(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(Load);
+  static NAN_METHOD(Unload);
+  static NAN_METHOD(PostMessage);
 
   static v8::Local<v8::Value> TransformMessageEvent(v8::Isolate* isolate,
       const gchar* name, guint index, const GValue* value, gpointer user_data);

--- a/src/script.h
+++ b/src/script.h
@@ -4,6 +4,7 @@
 #include "glib_object.h"
 
 #include <frida-core.h>
+#include <nan.h>
 
 namespace frida {
 
@@ -16,11 +17,11 @@ class Script : public GLibObject {
   explicit Script(FridaScript* handle, Runtime* runtime);
   ~Script();
 
-  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
-  static void Load(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Unload(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void PostMessage(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Load(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void Unload(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void PostMessage(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   static v8::Local<v8::Value> TransformMessageEvent(v8::Isolate* isolate,
       const gchar* name, guint index, const GValue* value, gpointer user_data);

--- a/src/script.h
+++ b/src/script.h
@@ -23,8 +23,8 @@ class Script : public GLibObject {
   static NAN_METHOD(Unload);
   static NAN_METHOD(PostMessage);
 
-  static v8::Local<v8::Value> TransformMessageEvent(v8::Isolate* isolate,
-      const gchar* name, guint index, const GValue* value, gpointer user_data);
+  static v8::Local<v8::Value> TransformMessageEvent(const gchar* name,
+      guint index, const GValue* value, gpointer user_data);
 
   v8::Persistent<v8::Object> events_;
 };

--- a/src/session.cc
+++ b/src/session.cc
@@ -72,7 +72,7 @@ Local<Object> Session::New(gpointer handle, Runtime* runtime) {
   return ctor->NewInstance(argc, argv);
 }
 
-void Session::New(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Session::New) {
   HandleScope();
 
   if (info.IsConstructCall()) {
@@ -100,8 +100,7 @@ void Session::New(const Nan::FunctionCallbackInfo<Value>& info) {
   }
 }
 
-void Session::GetPid(Local<String> property,
-    const Nan::PropertyCallbackInfo<Value>& info) {
+NAN_PROPERTY_GETTER(Session::GetPid) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -127,7 +126,7 @@ class DetachOperation : public Operation<FridaSession> {
   }
 };
 
-void Session::Detach(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Session::Detach) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -170,8 +169,7 @@ class CreateScriptOperation : public Operation<FridaSession> {
   gchar* source_;
   FridaScript* script_;
 };
-
-void Session::CreateScript(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Session::CreateScript) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -217,7 +215,7 @@ class EnableDebuggerOperation : public Operation<FridaSession> {
   guint16 port_;
 };
 
-void Session::EnableDebugger(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Session::EnableDebugger) {
   HandleScope();
 
   auto isolate = info.GetIsolate();
@@ -251,7 +249,7 @@ class DisableDebuggerOperation : public Operation<FridaSession> {
   }
 };
 
-void Session::DisableDebugger(const Nan::FunctionCallbackInfo<Value>& info) {
+NAN_METHOD(Session::DisableDebugger) {
   HandleScope();
 
   auto isolate = info.GetIsolate();

--- a/src/session.cc
+++ b/src/session.cc
@@ -69,7 +69,7 @@ Local<Object> Session::New(gpointer handle, Runtime* runtime) {
       runtime->GetDataPointer(SESSION_DATA_CONSTRUCTOR)));
   const int argc = 1;
   Local<Value> argv[argc] = { External::New(isolate, handle) };
-  return ctor->NewInstance(argc, argv);
+  return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 
 NAN_METHOD(Session::New) {

--- a/src/session.cc
+++ b/src/session.cc
@@ -73,7 +73,7 @@ Local<Object> Session::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Session::New) {
-  HandleScope();
+  HandleScope scope;
 
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
@@ -101,7 +101,7 @@ NAN_METHOD(Session::New) {
 }
 
 NAN_PROPERTY_GETTER(Session::GetPid) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Session>(
@@ -127,7 +127,7 @@ class DetachOperation : public Operation<FridaSession> {
 };
 
 NAN_METHOD(Session::Detach) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -170,7 +170,7 @@ class CreateScriptOperation : public Operation<FridaSession> {
   FridaScript* script_;
 };
 NAN_METHOD(Session::CreateScript) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -216,7 +216,7 @@ class EnableDebuggerOperation : public Operation<FridaSession> {
 };
 
 NAN_METHOD(Session::EnableDebugger) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
@@ -250,7 +250,7 @@ class DisableDebuggerOperation : public Operation<FridaSession> {
 };
 
 NAN_METHOD(Session::DisableDebugger) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();

--- a/src/session.cc
+++ b/src/session.cc
@@ -12,15 +12,12 @@
 
 using v8::AccessorSignature;
 using v8::DEFAULT;
-using v8::Exception;
 using v8::External;
 using v8::Function;
 using v8::Handle;
-using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
-using v8::Persistent;
 using v8::ReadOnly;
 using v8::String;
 using v8::Value;
@@ -42,7 +39,7 @@ void Session::Init(Handle<Object> exports, Runtime* runtime) {
   auto isolate = Isolate::GetCurrent();
 
   auto name = Nan::New("Session").ToLocalChecked();
-  auto tpl = CreateTemplate(isolate, name, Session::New, runtime);
+  auto tpl = CreateTemplate(name, Session::New, runtime);
 
   auto instance_tpl = tpl->InstanceTemplate();
   auto data = Handle<Value>();
@@ -62,13 +59,11 @@ void Session::Init(Handle<Object> exports, Runtime* runtime) {
 }
 
 Local<Object> Session::New(gpointer handle, Runtime* runtime) {
-  auto isolate = Isolate::GetCurrent();
-
-  auto ctor = Local<Function>::New(isolate,
-      *static_cast<v8::Persistent<Function>*>(
+  auto ctor = Nan::New<v8::Function>(
+    *static_cast<v8::Persistent<Function>*>(
       runtime->GetDataPointer(SESSION_DATA_CONSTRUCTOR)));
   const int argc = 1;
-  Local<Value> argv[argc] = { External::New(isolate, handle) };
+  Local<Value> argv[argc] = { Nan::New<v8::External>(handle) };
   return Nan::NewInstance(ctor, argc, argv).ToLocalChecked();
 }
 
@@ -103,12 +98,11 @@ NAN_METHOD(Session::New) {
 NAN_PROPERTY_GETTER(Session::GetPid) {
   HandleScope scope;
 
-  auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Session>(
       info.Holder())->GetHandle<FridaSession>();
 
-  info.GetReturnValue().Set(
-      Integer::NewFromUnsigned(isolate, frida_session_get_pid(handle)));
+  info.GetReturnValue().Set(Nan::New<v8::Uint32>(
+      frida_session_get_pid(handle)));
 }
 
 class DetachOperation : public Operation<FridaSession> {
@@ -122,7 +116,7 @@ class DetachOperation : public Operation<FridaSession> {
   }
 
   Local<Value> Result(Isolate* isolate) {
-    return Undefined(isolate);
+    return Nan::Undefined();
   }
 };
 
@@ -209,7 +203,7 @@ class EnableDebuggerOperation : public Operation<FridaSession> {
   }
 
   Local<Value> Result(Isolate* isolate) {
-    return Undefined(isolate);
+    return Nan::Undefined();
   }
 
   guint16 port_;
@@ -245,7 +239,7 @@ class DisableDebuggerOperation : public Operation<FridaSession> {
   }
 
   Local<Value> Result(Isolate* isolate) {
-    return Undefined(isolate);
+    return Nan::Undefined();
   }
 };
 

--- a/src/session.h
+++ b/src/session.h
@@ -4,6 +4,7 @@
 #include "glib_object.h"
 
 #include <frida-core.h>
+#include <nan.h>
 
 namespace frida {
 
@@ -16,15 +17,15 @@ class Session : public GLibObject {
   explicit Session(FridaSession* handle, Runtime* runtime);
   ~Session();
 
-  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   static void GetPid(v8::Local<v8::String> property,
-      const v8::PropertyCallbackInfo<v8::Value>& info);
+      const Nan::PropertyCallbackInfo<v8::Value>& info);
 
-  static void Detach(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void CreateScript(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void EnableDebugger(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void DisableDebugger(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Detach(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void CreateScript(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void EnableDebugger(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void DisableDebugger(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   v8::Persistent<v8::Object> events_;
 };

--- a/src/session.h
+++ b/src/session.h
@@ -17,15 +17,14 @@ class Session : public GLibObject {
   explicit Session(FridaSession* handle, Runtime* runtime);
   ~Session();
 
-  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(New);
 
-  static void GetPid(v8::Local<v8::String> property,
-      const Nan::PropertyCallbackInfo<v8::Value>& info);
+  static NAN_PROPERTY_GETTER(GetPid);
 
-  static void Detach(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void CreateScript(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void EnableDebugger(const Nan::FunctionCallbackInfo<v8::Value>& info);
-  static void DisableDebugger(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static NAN_METHOD(Detach);
+  static NAN_METHOD(CreateScript);
+  static NAN_METHOD(EnableDebugger);
+  static NAN_METHOD(DisableDebugger);
 
   v8::Persistent<v8::Object> events_;
 };

--- a/src/usage_monitor.h
+++ b/src/usage_monitor.h
@@ -84,7 +84,7 @@ class UsageMonitor {
 
   static void OnWeakNotifyWrapper(
       const v8::WeakCallbackData<v8::Object, UsageMonitor<T>>& data) {
-    HandleScope();
+    HandleScope scope;
     data.GetParameter()->OnWeakNotify();
   }
 

--- a/src/usage_monitor.h
+++ b/src/usage_monitor.h
@@ -6,6 +6,8 @@
 #include <v8.h>
 #include <nan.h>
 
+using Nan::HandleScope;
+
 namespace frida {
 
 template<typename T>
@@ -82,7 +84,7 @@ class UsageMonitor {
 
   static void OnWeakNotifyWrapper(
       const v8::WeakCallbackData<v8::Object, UsageMonitor<T>>& data) {
-    NanScope();
+    HandleScope();
     data.GetParameter()->OnWeakNotify();
   }
 

--- a/src/uv_context.cc
+++ b/src/uv_context.cc
@@ -15,7 +15,6 @@ using v8::Function;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
-using v8::String;
 using v8::Value;
 using Nan::HandleScope;
 
@@ -29,7 +28,7 @@ UVContext::UVContext(uv_loop_t* loop) : usage_count_(0), pending_(NULL) {
   g_cond_init(&cond_);
 
   auto isolate = Isolate::GetCurrent();
-  auto module = Object::New(isolate);
+  auto module = Nan::New<v8::Object>();
   auto process_pending = Function::New(isolate, ProcessPendingWrapper,
       External::New(isolate, this));
   auto process_pending_name = Nan::New("processPending").ToLocalChecked();
@@ -108,8 +107,8 @@ void UVContext::ProcessPendingWrapper(uv_async_t* handle) {
   auto isolate = Isolate::GetCurrent();
 
   auto self = static_cast<UVContext*>(handle->data);
-  auto module = Local<Object>::New(isolate, self->module_);
-  auto process_pending = Local<Function>::New(isolate, self->process_pending_);
+  auto module = Nan::New<v8::Object>(self->module_);
+  auto process_pending = Nan::New<v8::Function>(self->process_pending_);
   node::MakeCallback(isolate, module, process_pending, 0, NULL);
 }
 

--- a/src/uv_context.cc
+++ b/src/uv_context.cc
@@ -103,7 +103,7 @@ void UVContext::ProcessPendingWrapper(const v8::FunctionCallbackInfo<Value>& inf
 }
 
 void UVContext::ProcessPendingWrapper(uv_async_t* handle) {
-  HandleScope();
+  HandleScope scope;
 
   auto isolate = Isolate::GetCurrent();
 

--- a/src/uv_context.cc
+++ b/src/uv_context.cc
@@ -12,12 +12,12 @@
 using v8::Context;
 using v8::External;
 using v8::Function;
-using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
 using v8::String;
 using v8::Value;
+using Nan::HandleScope;
 
 namespace frida {
 
@@ -32,9 +32,9 @@ UVContext::UVContext(uv_loop_t* loop) : usage_count_(0), pending_(NULL) {
   auto module = Object::New(isolate);
   auto process_pending = Function::New(isolate, ProcessPendingWrapper,
       External::New(isolate, this));
-  auto process_pending_name = NanNew("processPending");
+  auto process_pending_name = Nan::New("processPending").ToLocalChecked();
   process_pending->SetName(process_pending_name);
-  module->Set(process_pending_name, process_pending);
+  Nan::Set(module, process_pending_name, process_pending);
   module_.Reset(isolate, module);
   process_pending_.Reset(isolate, process_pending);
 }
@@ -96,14 +96,14 @@ void UVContext::ProcessPending() {
   UV_CONTEXT_UNLOCK();
 }
 
-void UVContext::ProcessPendingWrapper(const FunctionCallbackInfo<Value>& args) {
+void UVContext::ProcessPendingWrapper(const v8::FunctionCallbackInfo<Value>& info) {
   UVContext* self = static_cast<UVContext*>(
-      args.Data().As<External>()->Value ());
+      info.Data().As<External>()->Value ());
   self->ProcessPending();
 }
 
 void UVContext::ProcessPendingWrapper(uv_async_t* handle) {
-  NanScope();
+  HandleScope();
 
   auto isolate = Isolate::GetCurrent();
 

--- a/src/uv_context.h
+++ b/src/uv_context.h
@@ -22,7 +22,7 @@ public:
 
 private:
   void ProcessPending();
-  static void ProcessPendingWrapper(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void ProcessPendingWrapper(const v8::FunctionCallbackInfo<v8::Value>& info);
   static void ProcessPendingWrapper(uv_async_t* handle);
 
   int usage_count_;


### PR DESCRIPTION
So, this PR adds support for the latest Nan version.

~~Currently, iojs **2.x** and node **0.12** fail the tests with `node(31257,0x7fff73507300) malloc: *** error for object 0x104d2f870: pointer being freed was not allocated` but iojs **3.x** works fine. My debugging skills are limited so I may need some help here.~~

~~*Should not be merged as is*~~