### PR TITLE
use prebuild instead of node-pre-gyp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /lib/binding
 /node_modules
+npm-debug.log
+prebuilds/

--- a/.prebuildrc
+++ b/.prebuildrc
@@ -1,0 +1,14 @@
+# abi 14
+target[] = 0.12.7
+
+# abi 42
+target[] = 1.0.4
+
+# abi 43
+target[] = 1.8.4
+
+# abi 44
+target[] = 2.5.0
+
+# abi 45
+target[] = 3.0.0

--- a/binding.gyp
+++ b/binding.gyp
@@ -136,16 +136,5 @@
         }],
       ],
     },
-    {
-      "target_name": "action_after_build",
-      "type": "none",
-      "dependencies": [ "<(module_name)" ],
-      "copies": [
-        {
-          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
-          "destination": "<(module_path)",
-        },
-      ]
-    },
   ],
 }

--- a/lib/frida.js
+++ b/lib/frida.js
@@ -35,11 +35,7 @@ exports.getDeviceManager = getDeviceManager;
 exports.ptr = require('./ptr');
 
 
-var binary = require('node-pre-gyp');
-var path = require('path');
-var bindingPath = binary.find(path.resolve(
-    path.join(__dirname, '../package.json')));
-var binding = require(bindingPath);
+var binding = require('bindings')('frida_binding');
 var DeviceManager = require('./device_manager');
 var deviceManager = null;
 

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
   "main": "./lib/frida",
   "dependencies": {
     "big-integer": "^1.4.4",
+    "bindings": "^1.2.1",
     "minimatch": "*",
     "nan": "^2.0.5",
-    "node-pre-gyp": "0.6.x"
+    "prebuild": "^2.5.1"
   },
   "devDependencies": {
     "co": "^4.5.4",
@@ -37,15 +38,14 @@
     "should": "^5.1.0"
   },
   "scripts": {
-    "install": "node-pre-gyp install",
+    "install": "prebuild --download",
     "pretest": "jshint lib test",
-    "test": "node-pre-gyp rebuild && node --expose-gc node_modules/mocha/bin/_mocha"
+    "prebuild": "prebuild --verbose --strip",
+    "test": "npm run prebuild && node --expose-gc node_modules/mocha/bin/_mocha"
   },
   "binary": {
     "module_name": "frida_binding",
-    "module_path": "./lib/binding/{configuration}/{node_abi}-{platform}-{arch}/",
-    "remote_path": "./node/v{version}/{configuration}/",
-    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz",
+    "remote_path": "node/v{version}",
     "host": "https://build.frida.re"
   },
   "repository": {


### PR DESCRIPTION
Issuing the following command in `frida-node` folder:

```
$ npm run prebuild
```

Will build `.tar.gz` files for *all* different abi versions of node/iojs:

![frida-prebuild](https://cloud.githubusercontent.com/assets/308049/9699694/7da1a1ea-53ec-11e5-97dd-4b794ee7312b.png)

All debug information is also stripped for `darwin` and `linux` architectures.