### PR TITLE
Nan updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "big-integer": "^1.4.4",
     "minimatch": "*",
-    "nan": "^2.0.5",
+    "nan": "^2.0.9",
     "node-pre-gyp": "0.6.x"
   },
   "devDependencies": {

--- a/src/application.cc
+++ b/src/application.cc
@@ -17,7 +17,6 @@ using v8::Local;
 using v8::Object;
 using v8::ReadOnly;
 using v8::Value;
-using Nan::HandleScope;
 
 namespace frida {
 
@@ -67,8 +66,6 @@ Local<Object> Application::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Application::New) {
-  HandleScope scope;
-
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
       Nan::ThrowTypeError("Bad argument, expected raw handle");
@@ -89,8 +86,6 @@ NAN_METHOD(Application::New) {
 }
 
 NAN_PROPERTY_GETTER(Application::GetIdentifier) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Application>(
       info.Holder())->GetHandle<FridaApplication>();
 
@@ -99,8 +94,6 @@ NAN_PROPERTY_GETTER(Application::GetIdentifier) {
 }
 
 NAN_PROPERTY_GETTER(Application::GetName) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Application>(
       info.Holder())->GetHandle<FridaApplication>();
 
@@ -109,8 +102,6 @@ NAN_PROPERTY_GETTER(Application::GetName) {
 }
 
 NAN_PROPERTY_GETTER(Application::GetPid) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto handle = ObjectWrap::Unwrap<Application>(
       info.Holder())->GetHandle<FridaApplication>();
@@ -120,8 +111,6 @@ NAN_PROPERTY_GETTER(Application::GetPid) {
 }
 
 NAN_PROPERTY_GETTER(Application::GetSmallIcon) {
-  HandleScope scope;
-
   auto wrapper = ObjectWrap::Unwrap<Application>(info.Holder());
   auto handle = wrapper->GetHandle<FridaApplication>();
 
@@ -130,8 +119,6 @@ NAN_PROPERTY_GETTER(Application::GetSmallIcon) {
 }
 
 NAN_PROPERTY_GETTER(Application::GetLargeIcon) {
-  HandleScope scope;
-
   auto wrapper = ObjectWrap::Unwrap<Application>(info.Holder());
   auto handle = wrapper->GetHandle<FridaApplication>();
 

--- a/src/device.cc
+++ b/src/device.cc
@@ -24,7 +24,6 @@ using v8::Object;
 using v8::ReadOnly;
 using v8::String;
 using v8::Value;
-using Nan::HandleScope;
 
 namespace frida {
 
@@ -84,8 +83,6 @@ Local<Object> Device::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Device::New) {
-  HandleScope scope;
-
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
       Nan::ThrowTypeError("Bad argument, expected raw handle");
@@ -114,8 +111,6 @@ NAN_METHOD(Device::New) {
 }
 
 NAN_PROPERTY_GETTER(Device::GetId) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Device>(
       info.Holder())->GetHandle<FridaDevice>();
 
@@ -124,8 +119,6 @@ NAN_PROPERTY_GETTER(Device::GetId) {
 }
 
 NAN_PROPERTY_GETTER(Device::GetName) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Device>(
       info.Holder())->GetHandle<FridaDevice>();
 
@@ -134,8 +127,6 @@ NAN_PROPERTY_GETTER(Device::GetName) {
 }
 
 NAN_PROPERTY_GETTER(Device::GetIcon) {
-  HandleScope scope;
-
   auto wrapper = ObjectWrap::Unwrap<Device>(info.Holder());
   auto handle = wrapper->GetHandle<FridaDevice>();
 
@@ -144,8 +135,6 @@ NAN_PROPERTY_GETTER(Device::GetIcon) {
 }
 
 NAN_PROPERTY_GETTER(Device::GetType) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Device>(
       info.Holder())->GetHandle<FridaDevice>();
 
@@ -192,8 +181,6 @@ class GetFrontmostApplicationOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::GetFrontmostApplication) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Device>(obj);
@@ -234,8 +221,6 @@ class EnumerateApplicationsOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::EnumerateApplications) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Device>(obj);
@@ -276,8 +261,6 @@ class EnumerateProcessesOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::EnumerateProcesses) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Device>(obj);
@@ -304,8 +287,6 @@ class EnableSpawnGatingOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::EnableSpawnGating) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Device>(obj);
@@ -332,8 +313,6 @@ class DisableSpawnGatingOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::DisableSpawnGating) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Device>(obj);
@@ -374,8 +353,6 @@ class EnumeratePendingSpawnsOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::EnumeratePendingSpawns) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Device>(obj);
@@ -420,8 +397,6 @@ class SpawnOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::Spawn) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Device>(obj);
@@ -479,15 +454,12 @@ class ResumeOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::Resume) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Device>(obj);
 
   if (info.Length() < 1 || !info[0]->IsNumber()) {
     Nan::ThrowTypeError("Bad argument, expected pid");
-    return;
   }
   auto pid = info[0]->ToInteger()->Value();
   if (pid <= 0) {
@@ -522,8 +494,6 @@ class KillOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::Kill) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Device>(obj);
@@ -568,8 +538,6 @@ class AttachOperation : public Operation<FridaDevice> {
 };
 
 NAN_METHOD(Device::Attach) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Device>(obj);

--- a/src/device_manager.cc
+++ b/src/device_manager.cc
@@ -15,7 +15,6 @@ using v8::Isolate;
 using v8::Local;
 using v8::Object;
 using v8::Value;
-using Nan::HandleScope;
 
 namespace frida {
 
@@ -60,8 +59,6 @@ void DeviceManager::Dispose(Runtime* runtime) {
 }
 
 NAN_METHOD(DeviceManager::New) {
-  HandleScope scope;
-
   if (info.IsConstructCall()) {
     auto runtime = GetRuntimeFromConstructorArgs(info);
 
@@ -100,8 +97,6 @@ class CloseOperation : public Operation<FridaDeviceManager> {
 };
 
 NAN_METHOD(DeviceManager::Close) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<DeviceManager>(obj);
@@ -142,8 +137,6 @@ class EnumerateDevicesOperation : public Operation<FridaDeviceManager> {
 };
 
 NAN_METHOD(DeviceManager::EnumerateDevices) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<DeviceManager>(obj);

--- a/src/events.cc
+++ b/src/events.cc
@@ -19,7 +19,6 @@ using v8::Object;
 using v8::Persistent;
 using v8::String;
 using v8::Value;
-using Nan::HandleScope;
 
 namespace frida {
 
@@ -108,8 +107,6 @@ void Events::SetUnlistenCallback(UnlistenCallback callback,
 }
 
 NAN_METHOD(Events::New) {
-  HandleScope scope;
-
   if (info.IsConstructCall()) {
     if (info.Length() != 3 ||
         !info[0]->IsExternal() ||
@@ -133,8 +130,6 @@ NAN_METHOD(Events::New) {
 }
 
 NAN_METHOD(Events::Listen) {
-  HandleScope scope;
-
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Events>(obj);
   auto runtime = wrapper->runtime_;
@@ -163,8 +158,6 @@ NAN_METHOD(Events::Listen) {
 }
 
 NAN_METHOD(Events::Unlisten) {
-  HandleScope scope;
-
   auto wrapper = ObjectWrap::Unwrap<Events>(info.Holder());
 
   guint signal_id;

--- a/src/icon.cc
+++ b/src/icon.cc
@@ -16,7 +16,6 @@ using v8::Local;
 using v8::Object;
 using v8::ReadOnly;
 using v8::Value;
-using Nan::HandleScope;
 
 namespace frida {
 
@@ -66,8 +65,6 @@ Local<Value> Icon::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Icon::New) {
-  HandleScope scope;
-
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
       Nan::ThrowTypeError("Bad argument, expected raw handle");
@@ -88,8 +85,6 @@ NAN_METHOD(Icon::New) {
 }
 
 NAN_PROPERTY_GETTER(Icon::GetWidth) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Icon>(
       info.Holder())->GetHandle<FridaIcon>();
 
@@ -98,8 +93,6 @@ NAN_PROPERTY_GETTER(Icon::GetWidth) {
 }
 
 NAN_PROPERTY_GETTER(Icon::GetHeight) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Icon>(
       info.Holder())->GetHandle<FridaIcon>();
 
@@ -108,8 +101,6 @@ NAN_PROPERTY_GETTER(Icon::GetHeight) {
 }
 
 NAN_PROPERTY_GETTER(Icon::GetRowstride) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Icon>(
       info.Holder())->GetHandle<FridaIcon>();
 
@@ -118,8 +109,6 @@ NAN_PROPERTY_GETTER(Icon::GetRowstride) {
 }
 
 NAN_PROPERTY_GETTER(Icon::GetPixels) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Icon>(
       info.Holder())->GetHandle<FridaIcon>();
 

--- a/src/process.cc
+++ b/src/process.cc
@@ -16,7 +16,6 @@ using v8::Local;
 using v8::Object;
 using v8::ReadOnly;
 using v8::Value;
-using Nan::HandleScope;
 
 namespace frida {
 
@@ -63,8 +62,6 @@ Local<Object> Process::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Process::New) {
-  HandleScope scope;
-
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
       Nan::ThrowTypeError("Bad argument, expected raw handle");
@@ -85,8 +82,6 @@ NAN_METHOD(Process::New) {
 }
 
 NAN_PROPERTY_GETTER(Process::GetPid) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Process>(
       info.Holder())->GetHandle<FridaProcess>();
 
@@ -95,8 +90,6 @@ NAN_PROPERTY_GETTER(Process::GetPid) {
 }
 
 NAN_PROPERTY_GETTER(Process::GetName) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Process>(
       info.Holder())->GetHandle<FridaProcess>();
 
@@ -105,8 +98,6 @@ NAN_PROPERTY_GETTER(Process::GetName) {
 }
 
 NAN_PROPERTY_GETTER(Process::GetSmallIcon) {
-  HandleScope scope;
-
   auto wrapper = ObjectWrap::Unwrap<Process>(info.Holder());
   auto handle = wrapper->GetHandle<FridaProcess>();
 
@@ -115,8 +106,6 @@ NAN_PROPERTY_GETTER(Process::GetSmallIcon) {
 }
 
 NAN_PROPERTY_GETTER(Process::GetLargeIcon) {
-  HandleScope scope;
-
   auto wrapper = ObjectWrap::Unwrap<Process>(info.Holder());
   auto handle = wrapper->GetHandle<FridaProcess>();
 

--- a/src/script.cc
+++ b/src/script.cc
@@ -18,7 +18,6 @@ using v8::Local;
 using v8::Object;
 using v8::String;
 using v8::Value;
-using Nan::HandleScope;
 
 namespace frida {
 
@@ -58,8 +57,6 @@ Local<Object> Script::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Script::New) {
-  HandleScope scope;
-
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
       Nan::ThrowTypeError("Bad argument, expected raw handle");
@@ -101,8 +98,6 @@ class LoadOperation : public Operation<FridaScript> {
 };
 
 NAN_METHOD(Script::Load) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Script>(obj);
@@ -129,8 +124,6 @@ class UnloadOperation : public Operation<FridaScript> {
 };
 
 NAN_METHOD(Script::Unload) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Script>(obj);
@@ -166,8 +159,6 @@ class PostMessageOperation : public Operation<FridaScript> {
 };
 
 NAN_METHOD(Script::PostMessage) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Script>(obj);

--- a/src/session.cc
+++ b/src/session.cc
@@ -21,7 +21,6 @@ using v8::Object;
 using v8::ReadOnly;
 using v8::String;
 using v8::Value;
-using Nan::HandleScope;
 
 namespace frida {
 
@@ -68,8 +67,6 @@ Local<Object> Session::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Session::New) {
-  HandleScope scope;
-
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
       Nan::ThrowTypeError("Bad argument, expected raw handle");
@@ -96,8 +93,6 @@ NAN_METHOD(Session::New) {
 }
 
 NAN_PROPERTY_GETTER(Session::GetPid) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Session>(
       info.Holder())->GetHandle<FridaSession>();
 
@@ -121,8 +116,6 @@ class DetachOperation : public Operation<FridaSession> {
 };
 
 NAN_METHOD(Session::Detach) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Session>(obj);
@@ -164,8 +157,6 @@ class CreateScriptOperation : public Operation<FridaSession> {
   FridaScript* script_;
 };
 NAN_METHOD(Session::CreateScript) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Session>(obj);
@@ -210,8 +201,6 @@ class EnableDebuggerOperation : public Operation<FridaSession> {
 };
 
 NAN_METHOD(Session::EnableDebugger) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Session>(obj);
@@ -244,8 +233,6 @@ class DisableDebuggerOperation : public Operation<FridaSession> {
 };
 
 NAN_METHOD(Session::DisableDebugger) {
-  HandleScope scope;
-
   auto isolate = info.GetIsolate();
   auto obj = info.Holder();
   auto wrapper = ObjectWrap::Unwrap<Session>(obj);

--- a/src/spawn.cc
+++ b/src/spawn.cc
@@ -16,7 +16,6 @@ using v8::Object;
 using v8::Persistent;
 using v8::ReadOnly;
 using v8::Value;
-using Nan::HandleScope;
 
 namespace frida {
 
@@ -59,8 +58,6 @@ Local<Object> Spawn::New(gpointer handle, Runtime* runtime) {
 }
 
 NAN_METHOD(Spawn::New) {
-  HandleScope scope;
-
   if (info.IsConstructCall()) {
     if (info.Length() != 1 || !info[0]->IsExternal()) {
       Nan::ThrowTypeError("Bad argument, expected raw handle");
@@ -81,8 +78,6 @@ NAN_METHOD(Spawn::New) {
 }
 
 NAN_PROPERTY_GETTER(Spawn::GetPid) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Spawn>(
       info.Holder())->GetHandle<FridaSpawn>();
 
@@ -90,8 +85,6 @@ NAN_PROPERTY_GETTER(Spawn::GetPid) {
 }
 
 NAN_PROPERTY_GETTER(Spawn::GetIdentifier) {
-  HandleScope scope;
-
   auto handle = ObjectWrap::Unwrap<Spawn>(
       info.Holder())->GetHandle<FridaSpawn>();
 


### PR DESCRIPTION
Few more nan updates. Scopes are not needed for exported functions now. 

Note: Ideally when we're creating new V8 values from user input we should be using `Nan::To` instead of `Nan::New` for conversion. V8 will return a `MaybeLocal` that we need to check, to check if the variable converted properly.