### PR TITLE
prebuild --install

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "should": "^5.1.0"
   },
   "scripts": {
-    "install": "prebuild --download",
+    "install": "prebuild --install",
     "pretest": "jshint lib test/*.js",
     "prebuild": "prebuild --verbose --strip",
     "test": "npm run prebuild && node --expose-gc node_modules/mocha/bin/_mocha"


### PR DESCRIPTION
@oleavr This will download the prebuilt binaries when installing from npm but will compile them in all other cases, e.g. if you're using a git link in package.json or if you have cloned the project and is working on it