### PR TITLE
add Script.setLogHandler method

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -13,6 +13,8 @@ var onDestroyedCallback = Symbol('onDestroyedCallback');
 var onMessage = Symbol('onMessage');
 var onMessageCallback = Symbol('onMessageCallback');
 var onRpcMessage = Symbol('onRpcMessage');
+var logHandler = Symbol('logHandler');
+var onLog = Symbol('onLog');
 
 function Script(impl) {
   Object.defineProperty(this, $, { value: impl });
@@ -21,6 +23,8 @@ function Script(impl) {
 
   this[pending] = {};
   this[nextRequestId] = 1;
+
+  this.setLogHandler();
 }
 
 Script.prototype.load = function () {
@@ -105,6 +109,30 @@ Script.prototype[onRpcMessage] = function (id, operation, params, data) {
   }
 };
 
+Script.prototype[onLog] = function(level, text) {
+  switch (level) {
+    case 'info':
+      console.log(text);
+      break;
+    case 'warning':
+      console.warn(text);
+      break;
+    case 'error':
+      console.error(text);
+      break;
+  }
+};
+
+Script.prototype.setLogHandler = function (handler) {
+  if (typeof handler === 'undefined') {
+    this.events[logHandler] = this[onLog].bind(this);
+  } else if (typeof handler === 'function') {
+    this.events[logHandler] = handler.bind(this);
+  } else {
+    throw new Error('illegal log handler ' + handler);
+  }
+};
+
 function ScriptEvents(impl, onRpcMessageCallback) {
   Object.defineProperty(this, $, { value: impl });
 
@@ -133,17 +161,7 @@ ScriptEvents.prototype[onMessage] = function (message, data) {
     this[onRpcMessage](id, operation, params, data);
   } else if (isLogMessage(message)) {
     const text = message.payload;
-    switch (message.level) {
-      case 'info':
-        console.log(text);
-        break;
-      case 'warning':
-        console.warn(text);
-        break;
-      case 'error':
-        console.error(text);
-        break;
-    }
+    this[logHandler](message.level, text);
   }
 };
 

--- a/lib/script.js
+++ b/lib/script.js
@@ -4,6 +4,7 @@ module.exports = Script;
 
 
 var $ = Symbol('impl');
+var logHandler = Symbol('logHandler');
 var messageHandlers = Symbol('messageHandlers');
 var nextRequestId = Symbol('nextRequestId');
 var pending = Symbol('pending');
@@ -13,8 +14,6 @@ var onDestroyedCallback = Symbol('onDestroyedCallback');
 var onMessage = Symbol('onMessage');
 var onMessageCallback = Symbol('onMessageCallback');
 var onRpcMessage = Symbol('onRpcMessage');
-var logHandler = Symbol('logHandler');
-var onLog = Symbol('onLog');
 
 function Script(impl) {
   Object.defineProperty(this, $, { value: impl });
@@ -24,7 +23,7 @@ function Script(impl) {
   this[pending] = {};
   this[nextRequestId] = 1;
 
-  this.setLogHandler();
+  this.setLogHandler(null);
 }
 
 Script.prototype.load = function () {
@@ -109,28 +108,8 @@ Script.prototype[onRpcMessage] = function (id, operation, params, data) {
   }
 };
 
-Script.prototype[onLog] = function(level, text) {
-  switch (level) {
-    case 'info':
-      console.log(text);
-      break;
-    case 'warning':
-      console.warn(text);
-      break;
-    case 'error':
-      console.error(text);
-      break;
-  }
-};
-
 Script.prototype.setLogHandler = function (handler) {
-  if (typeof handler === 'undefined') {
-    this.events[logHandler] = this[onLog].bind(this);
-  } else if (typeof handler === 'function') {
-    this.events[logHandler] = handler.bind(this);
-  } else {
-    throw new Error('illegal log handler ' + handler);
-  }
+  this.events[logHandler] = (handler !== null) ? handler.bind(this) : log;
 };
 
 function ScriptEvents(impl, onRpcMessageCallback) {
@@ -211,4 +190,18 @@ function isRpcMessage(message) {
   if (!(payload instanceof Array))
     return false;
   return payload[0] === 'frida:rpc';
+}
+
+function log(level, text) {
+  switch (level) {
+    case 'info':
+      console.log(text);
+      break;
+    case 'warning':
+      console.warn(text);
+      break;
+    case 'error':
+      console.error(text);
+      break;
+  }
 }

--- a/test/script.js
+++ b/test/script.js
@@ -142,4 +142,19 @@ describe('Script', function () {
     should(thrownException).not.equal(null);
     thrownException.message.should.equal('Script is destroyed');
   }));
+
+  it('should support custom log handler', co.wrap(function *() {
+    const script = yield session.createScript(
+      '"use strict";' +
+      '' +
+      'console.error(new Error("test message"))');
+
+    script.setLogHandler(function(level, text) {
+      should(level).equal('error');
+      should(text).equal('Error: test message');
+    });
+
+    yield script.load();
+    should('a').equal('a');
+  }));
 });

--- a/test/script.js
+++ b/test/script.js
@@ -149,12 +149,11 @@ describe('Script', function () {
       '' +
       'console.error(new Error("test message"))');
 
-    script.setLogHandler(function(level, text) {
+    script.setLogHandler(function (level, text) {
       should(level).equal('error');
       should(text).equal('Error: test message');
     });
 
     yield script.load();
-    should('a').equal('a');
   }));
 });


### PR DESCRIPTION
In python binding there's a method to intercept `console.log`:
https://github.com/frida/frida-python/blob/cfc8964c9da2c48f27dc6973768fd86f9e97d827/src/frida/core.py#L321

But in Node it is missing.
