### PR TITLE
Search frida_binding.node in current dir too

### DIFF
--- a/lib/frida.js
+++ b/lib/frida.js
@@ -53,7 +53,21 @@ exports.getDeviceManager = getDeviceManager;
 exports.ptr = require('./ptr');
 
 
-var binding = require('bindings')('frida_binding');
+var binding = require('bindings')({
+  bindings: 'frida_binding',
+  try: [
+    [ process.cwd(), 'bindings' ],
+    [ 'module_root', 'build', 'bindings' ],
+    [ 'module_root', 'build', 'Debug', 'bindings' ],
+    [ 'module_root', 'build', 'Release', 'bindings' ],
+    [ 'module_root', 'out', 'Debug', 'bindings' ],
+    [ 'module_root', 'Debug', 'bindings' ],
+    [ 'module_root', 'out', 'Release', 'bindings' ],
+    [ 'module_root', 'Release', 'bindings' ],
+    [ 'module_root', 'build', 'default', 'bindings' ],
+    [ 'module_root', 'compiled', 'version', 'platform', 'arch', 'bindings' ]
+  ]
+});
 var DeviceManager = require('./device_manager');
 var deviceManager = null;
 

--- a/lib/frida.js
+++ b/lib/frida.js
@@ -56,7 +56,6 @@ exports.ptr = require('./ptr');
 var binding = require('bindings')({
   bindings: 'frida_binding',
   try: [
-    [ process.cwd(), 'bindings' ],
     [ 'module_root', 'build', 'bindings' ],
     [ 'module_root', 'build', 'Debug', 'bindings' ],
     [ 'module_root', 'build', 'Release', 'bindings' ],
@@ -65,7 +64,8 @@ var binding = require('bindings')({
     [ 'module_root', 'out', 'Release', 'bindings' ],
     [ 'module_root', 'Release', 'bindings' ],
     [ 'module_root', 'build', 'default', 'bindings' ],
-    [ 'module_root', 'compiled', 'version', 'platform', 'arch', 'bindings' ]
+    [ 'module_root', 'compiled', 'version', 'platform', 'arch', 'bindings' ],
+    [ process.cwd(), 'bindings' ],
   ]
 });
 var DeviceManager = require('./device_manager');


### PR DESCRIPTION
This is needed for example when redistributing frida in a node project packaged with “pkg” tool

reference: https://www.npmjs.com/package/pkg#snapshot-filesystem

> On the other hand, in order to access real file system at run time (pick up a user's external javascript plugin, json configuration or even get a list of user's directory) you should take process.cwd() or path.dirname(process.execPath).