### PR TITLE
Expose default log handler

### DIFF
--- a/lib/script.ts
+++ b/lib/script.ts
@@ -29,8 +29,12 @@ export class Script {
         return this.logHandlerImpl;
     }
 
-    set logHandler(handler: ScriptLogHandler | null) {
-        this.logHandlerImpl = (handler !== null) ? handler : log;
+    set logHandler(handler: ScriptLogHandler) {
+        this.logHandlerImpl = handler;
+    }
+
+    get defaultLogHandler(): ScriptLogHandler {
+        return log;
     }
 
     load(cancellable?: Cancellable): Promise<void> {


### PR DESCRIPTION
- remove the ability to reset the handler by setting it to `null`
- make the `logHandler` property non-nullable