### PR TITLE
Fix iostream race

### DIFF
--- a/lib/iostream.ts
+++ b/lib/iostream.ts
@@ -14,9 +14,11 @@ export class IOStream extends Duplex {
     async _destroy(error: Error | null, callback: (error: Error | null) => void): Promise<void> {
         this.cancellable.cancel();
 
-        try {
-            await Promise.all(Array.from(this.pending));
-        } catch (e) {
+        for (const operation of this.pending) {
+            try {
+                await operation;
+            } catch (e) {
+            }
         }
 
         try {

--- a/src/operation.h
+++ b/src/operation.h
@@ -21,13 +21,13 @@ class Operation {
             .ToLocalChecked());
     runtime_ = parent->GetRuntime();
 
-    runtime_->GetUVContext()->IncreaseUsage();
-    runtime_->GetGLibContext()->Schedule([=]() { Begin(); });
-
     auto num_args = info.Length();
     if (num_args >= 1) {
       cancellable_ = Cancellable::TryParse(info[num_args - 1], runtime_);
     }
+
+    runtime_->GetUVContext()->IncreaseUsage();
+    runtime_->GetGLibContext()->Schedule([=]() { Begin(); });
   }
 
   v8::Local<v8::Promise> GetPromise(v8::Isolate* isolate) {


### PR DESCRIPTION
- Schedule operation’s `Begin()` after setting `cancellable_`, this avoid a race condition for which operations may have been impossible to cancel
- Ensure `IOStream` awaits all pending i/o before closing, even in presence of rejected promises