### PR TITLE
Fix leak in IOStream's WriteOperation

### DIFF
--- a/src/iostream.cc
+++ b/src/iostream.cc
@@ -214,7 +214,7 @@ class WriteOperation : public Operation<GIOStream> {
   }
 
   GOutputStream* stream_;
-  Persistent<Value> buffer_;
+  Persistent<Value, v8::CopyablePersistentTraits<Value>> buffer_;
   const void* data_;
   gsize count_;
 };


### PR DESCRIPTION
Apparently this allows the underlying buffer to be garbage collected when done.