### PR TITLE
#fixed docs: Node.js highest version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Node.js bindings for [Frida](http://www.frida.re).
 
 ## Depends
 
-- Node.js 8.x or newer
+- Node.js 8.x or newer (up to Node.js 12.x)
 
 ## Install
 


### PR DESCRIPTION
Due to complications in bindings.gyp, a lot of people have this issue with `Node.js` + `frida-node` implementation (just ask Google). Node.js defaulty to v15 as of 2020 so let users know the highest version supported.