### PR TITLE
fix: link frida-node against the inspector library

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -142,6 +142,7 @@
           "libraries": [
             "-lfrida-core-1.0",
             "-lfrida-gumjs-1.0",
+            "-lfrida-gumjs-inspector-1.0",
             "-lsoup-3.0",
             "-lnghttp2",
             "-lsqlite3",


### PR DESCRIPTION
Fixes

```
node: symbol lookup error: /frida-stealthspy/node_modules/frida/build/Release/frida_binding.node: undefined symbol: gum_inspector_server_new
```

when calling `await script.enableDebugger();`