### PR TITLE
Cancellable.combine

### DIFF
--- a/lib/cancellable.ts
+++ b/lib/cancellable.ts
@@ -29,6 +29,15 @@ export class Cancellable {
         return "Cancellable {}";
     }
 
+    combine (other: Cancellable): Cancellable {
+        const cancel = new Cancellable();
+        this.cancelled.connect(() => cancel.cancel());
+        other.cancelled.connect(() => cancel.cancel());
+        if (this.isCancelled) cancel.cancel();
+        if (other.isCancelled) cancel.cancel();
+        return cancel;
+    }
+
     public static withTimeout(ms): Cancellable {
         const cancel = new Cancellable();
         setTimeout(() => cancel.cancel(), ms).unref();

--- a/lib/cancellable.ts
+++ b/lib/cancellable.ts
@@ -29,7 +29,7 @@ export class Cancellable {
         return "Cancellable {}";
     }
 
-    combine (other: Cancellable): Cancellable {
+    combine(other: Cancellable): Cancellable {
         const cancel = new Cancellable();
         this.cancelled.connect(() => cancel.cancel());
         other.cancelled.connect(() => cancel.cancel());


### PR DESCRIPTION
`Cancellable.combine` allows for combining cancellations. 
This can be useful in scenarios like combining timeouts or combining timeout with user cancellation.

```js
function doSomething(cancellable) {
    const connectTimeout = cancellable.combine(Cancellable.withTimeout(2000));
    const appservice = await device.openService('xpc:com.apple.coredevice.appservice', connectTimeout);
}
```