### PR TITLE
Re add .withTimeout and .combine to Cancellable

### DIFF
--- a/src/frida_bindgen/customization.py
+++ b/src/frida_bindgen/customization.py
@@ -809,6 +809,29 @@ get isCancelled(): boolean {
 }
 """,
                     ),
+                    CustomMethod(
+                        typing="static withTimeout(ms: number): Cancellable",
+                        code="""
+static withTimeout(ms: number): Cancellable {
+    const cancel = new Cancellable();
+    setTimeout(() => cancel.cancel(), ms).unref();
+    return cancel;
+}
+""",
+                    ),
+                    CustomMethod(
+                        typing="combine(other: Cancellable): Cancellable",
+                        code="""
+combine(other: Cancellable): Cancellable {
+    const cancel = new Cancellable();
+    this.cancelled.connect(() => cancel.cancel());
+    other.cancelled.connect(() => cancel.cancel());
+    if (this.isCancelled) cancel.cancel();
+    if (other.isCancelled) cancel.cancel();
+    return cancel;
+}
+""",
+                    ),
                 ],
             ),
         ),

--- a/src/frida_bindgen/customization.py
+++ b/src/frida_bindgen/customization.py
@@ -813,9 +813,9 @@ get isCancelled(): boolean {
                         typing="static withTimeout(ms: number): Cancellable",
                         code="""
 static withTimeout(ms: number): Cancellable {
-    const cancel = new Cancellable();
-    setTimeout(() => cancel.cancel(), ms).unref();
-    return cancel;
+    const c = new Cancellable();
+    setTimeout(() => c.cancel(), ms).unref();
+    return c;
 }
 """,
                     ),
@@ -823,12 +823,14 @@ static withTimeout(ms: number): Cancellable {
                         typing="combine(other: Cancellable): Cancellable",
                         code="""
 combine(other: Cancellable): Cancellable {
-    const cancel = new Cancellable();
-    this.cancelled.connect(() => cancel.cancel());
-    other.cancelled.connect(() => cancel.cancel());
-    if (this.isCancelled) cancel.cancel();
-    if (other.isCancelled) cancel.cancel();
-    return cancel;
+    const c = new Cancellable();
+    this.cancelled.connect(() => c.cancel());
+    other.cancelled.connect(() => c.cancel());
+    if (this.isCancelled)
+        c.cancel();
+    if (other.isCancelled)
+        c.cancel();
+    return c;
 }
 """,
                     ),


### PR DESCRIPTION
Adds back #98 and #99 after it was accidentally dropped when moving to generated binding.
Test
```typescript
import { Cancellable } from "frida";

async function main() {
    const timeout = Cancellable.withTimeout(100);
    const cancel = new Cancellable();
    const combined = cancel.combine(timeout);
    await new Promise(resolve => setTimeout(resolve, 200));
    console.log("timeout.isCancelled:", timeout.isCancelled);
    console.log("cancel.isCancelled:", cancel.isCancelled);
    console.log("combined.isCancelled:", combined.isCancelled);
}

main();
```

```sh
node index.js
timeout.isCancelled: true
cancel.isCancelled: false
combined.isCancelled: true
```